### PR TITLE
fix(theme,plugin): remove dependency on short_open_tag (#45)

### DIFF
--- a/wp-content/plugins/academy-africa/includes/assets/images/all_courses.php
+++ b/wp-content/plugins/academy-africa/includes/assets/images/all_courses.php
@@ -318,6 +318,6 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
                 </section>
             </div>
         </main>
-<?
+<?php
     }
 }

--- a/wp-content/plugins/academy-africa/includes/widgets/all_courses.php
+++ b/wp-content/plugins/academy-africa/includes/widgets/all_courses.php
@@ -173,18 +173,18 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
         <main class="body">
             <div class="sidebar" id="sidebar">
                 <p class="filter-by">
-                    <? echo $filter_by ?>
+                    <?php echo $filter_by ?>
                 </p>
-                <?
+                <?php
                 if (!empty($filter_options)) {
                     foreach ($filter_options as $item) {
                         $title = $item["title"];
                         $options = $item["options"];
                 ?>
                         <p style="margin-top: 40px" class="filter-by-title">
-                            <? echo $title ?>
+                            <?php echo $title ?>
                         </p>
-                        <?
+                        <?php
                         if (!empty($options)) {
                             foreach ($options as $option) {
                         ?>
@@ -193,11 +193,11 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
                                         <label class="mui-checkbox">
                                             <input type="checkbox">
                                             <span class="checkmark"></span>
-                                            <? echo $option ?>
+                                            <?php echo $option ?>
                                         </label>
                                     </li>
                                 </ul>
-                <?
+                <?php
                             }
                         }
                     }
@@ -208,13 +208,13 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
             <div class="courses-main">
                 <section class="learning-pathways">
                     <h4 class="cfa-title">
-                        <? echo $learning_pathways_title ?>
+                        <?php echo $learning_pathways_title ?>
                     </h4>
                     <p class="description">
-                        <? echo $learning_pathways_description ?>
+                        <?php echo $learning_pathways_description ?>
                     </p>
                     <div class="content">
-                        <?
+                        <?php
                         if (!empty($learning_pathways)) {
                             foreach ($learning_pathways as $pathway) {
                                 $name = $pathway["title"];
@@ -223,19 +223,19 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
                                 <div class="card">
                                     <div class="course-card-pattern">
                                         <div class="icon">
-                                            <img src="<? echo $icon ?>" alt="sample-icon">
+                                            <img src="<?php echo $icon ?>" alt="sample-icon">
                                         </div>
                                     </div>
                                     <div class="pathway-card-content">
                                         <p class="pathway-name">
-                                            <? echo $name ?>
+                                            <?php echo $name ?>
                                         </p>
                                         <p class="course-count">
-                                            <? echo $pathway["courses"] ?>
+                                            <?php echo $pathway["courses"] ?>
                                         </p>
                                     </div>
                                 </div>
-                        <?
+                        <?php
                             }
                         }
                         ?>
@@ -266,17 +266,17 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
                 </section>
                 <section class="all-courses">
                     <h4 class="cfa-title">
-                        <? echo $courses_title ?>
+                        <?php echo $courses_title ?>
                     </h4>
                     <p class="description">
-                        <? echo $courses_description ?>
+                        <?php echo $courses_description ?>
                     </p>
                     <div class="key">
                         <div class="course-free-tag">
                             Free
                         </div>
                         <p class="key-text">
-                            <? echo $free_tag_key ?>
+                            <?php echo $free_tag_key ?>
                         </p>
                     </div>
                     <div class="key">
@@ -284,11 +284,11 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
                             paid
                         </div>
                         <p class="key-text">
-                            <? echo $paid_tag_key ?>
+                            <?php echo $paid_tag_key ?>
                         </p>
                     </div>
                     <div class="content">
-                        <?
+                        <?php
                         if (!empty($courses)) {
                             foreach ($courses as $course) {
                                 $title = $course['title'];
@@ -298,28 +298,28 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
                                 $image = $course['image'];
                         ?>
                                 <div class="card">
-                                    <img alt="course-logo" class="logo" src="<? echo $image ?>" />
+                                    <img alt="course-logo" class="logo" src="<?php echo $image ?>" />
                                     <div class="card-content">
                                         <div class="card-title">
                                             <p>
-                                                <? echo $title ?>
+                                                <?php echo $title ?>
                                             </p>
                                         </div>
                                         <p class="provider">
-                                            by <? echo $provider ?>
+                                            by <?php echo $provider ?>
                                         </p>
                                         <div class="card-footer">
                                             <div class="student-count">
                                                 <img alt="user" src="/wp-content/plugins/academy-africa/includes/assets/images/user.svg" />
-                                                <span><? echo $student_count ?></span>
+                                                <span><?php echo $student_count ?></span>
                                             </div>
                                             <div class="tag free">
-                                                <? echo $price ?>
+                                                <?php echo $price ?>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
-                        <?
+                        <?php
                             }
                         }
                         ?>
@@ -350,6 +350,6 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
                 </section>
             </div>
         </main>
-<?
+<?php
     }
 }

--- a/wp-content/plugins/academy-africa/includes/widgets/connect_and_collaborate.php
+++ b/wp-content/plugins/academy-africa/includes/widgets/connect_and_collaborate.php
@@ -101,7 +101,7 @@ class Academy_Africa_Connect_and_Collaborate extends \Elementor\Widget_Base
         <div class="connect">
             <div class="cfa-title-centered">
                 <h4>
-                    <? echo $title ?>
+                    <?php echo $title ?>
                 </h4>
             </div>
             <div class="content">
@@ -111,17 +111,17 @@ class Academy_Africa_Connect_and_Collaborate extends \Elementor\Widget_Base
                 </div>
                 <div class="banner center">
                     <p class="share">
-                        <? echo $share_text ?>
+                        <?php echo $share_text ?>
                     </p>
                     <p class="become-a-member">
-                        <? echo $become_a_member_text ?>
+                        <?php echo $become_a_member_text ?>
                     </p>
                     <a href=src="<?php echo $about_us_url ?>" class="primary-button">
-                        <? echo $join_us_on_slack ?>
+                        <?php echo $join_us_on_slack ?>
                     </a>
                 </div>
             </div>
         </div>
-        <?
+        <?php
     }
 }

--- a/wp-content/plugins/academy-africa/includes/widgets/error.php
+++ b/wp-content/plugins/academy-africa/includes/widgets/error.php
@@ -97,25 +97,25 @@ class Academy_Africa_Error extends \Elementor\Widget_Base
             <div></div>
             <div class="content">
                 <p class="code" <?php echo $this->get_render_attribute_string('status_code'); ?>>
-                    <? echo $status_code ?>
+                    <?php echo $status_code ?>
                 </p>
                 <p class="text" <?php echo $this->get_render_attribute_string('title'); ?>>
-                    <? echo $title ?>
+                    <?php echo $title ?>
                 </p>
                 <p class="description" <?php echo $this->get_render_attribute_string('description'); ?>>
-                    <? echo $description ?>
+                    <?php echo $description ?>
                 </p>
                 <div class="actions">
                     <a class="button" href="" onclick="location.reload();" <?php echo $this->get_render_attribute_string('refresh'); ?>>
-                        <? echo $refresh ?>
+                        <?php echo $refresh ?>
                     </a>
                     <a class="button" href="/" <?php echo $this->get_render_attribute_string('home'); ?>>
-                        <? echo $home ?>
+                        <?php echo $home ?>
                     </a>
                 </div>
             </div>
 
         </div>
-<?
+<?php
     }
 }

--- a/wp-content/plugins/academy-africa/includes/widgets/featured_courses.php
+++ b/wp-content/plugins/academy-africa/includes/widgets/featured_courses.php
@@ -247,7 +247,7 @@ class Academy_Africa_Featured_Courses extends \Elementor\Widget_Base
             <!-- Fetch from Learndash -->
             <div class="neutral-bg">
                 <div class="content">
-                    <?
+                    <?php
                     if (!empty($courses)) {
                         foreach ($courses as $course) {
                             $title = $course['title'];
@@ -281,7 +281,7 @@ class Academy_Africa_Featured_Courses extends \Elementor\Widget_Base
                                     </div>
                                 </div>
                             </div>
-                            <?
+                            <?php
                         }
                     }
                     ?>
@@ -298,10 +298,10 @@ class Academy_Africa_Featured_Courses extends \Elementor\Widget_Base
                         <div class="flex-items">
                             <div style="flex: 1">
                                 <p class="certificate-of">
-                                    <? echo $certificate_title ?>
+                                    <?php echo $certificate_title ?>
                                 </p>
                                 <p class="certificate-type">
-                                    <? echo $certificate_type ?>
+                                    <?php echo $certificate_type ?>
                                 </p>
                                 <hr>
                                 </hr>
@@ -326,59 +326,59 @@ class Academy_Africa_Featured_Courses extends \Elementor\Widget_Base
                         <div class="course-details">
                             <div class="student">
                                 <p class="title">
-                                    <? echo $presented_to ?>
+                                    <?php echo $presented_to ?>
                                 </p>
                                 <p class="first-name">
-                                    <? echo $user['first_name'] ?>
+                                    <?php echo $user['first_name'] ?>
                                 </p>
                                 <p class="last-name">
-                                    <? echo $user['last_name'] ?>
+                                    <?php echo $user['last_name'] ?>
                                 </p>
                             </div>
                             <div class="course">
                                 <p class="course-description">
-                                    <? echo $certificate_description ?>
+                                    <?php echo $certificate_description ?>
                                 </p>
                                 <p class="course-name">
-                                    <? echo $certificate_course ?>
+                                    <?php echo $certificate_course ?>
                                 </p>
                             </div>
                         </div>
                     </div>
                     <div class="certificate-footer">
-                        <img height="40px" width="40px" alt="logo" src="<? echo $art_board ?>" />
+                        <img height="40px" width="40px" alt="logo" src="<?php echo $art_board ?>" />
                         <p class="company-name">
-                            <? echo $company_name ?>
+                            <?php echo $company_name ?>
                         </p>
-                        <img alt="artwork" src="<? echo $company_image ?>" />
+                        <img alt="artwork" src="<?php echo $company_image ?>" />
                         <div class="signature">
-                            <img alt="signature" alt="<? echo $academy_head['name'] ?>"
-                                src="<? echo $academy_head['signature'] ?>" />
+                            <img alt="signature" alt="<?php echo $academy_head['name'] ?>"
+                                src="<?php echo $academy_head['signature'] ?>" />
                             <p class="signee-name">
-                                <? echo $academy_head['name'] ?>
+                                <?php echo $academy_head['name'] ?>
                             </p>
                             <p class="signee-role">
-                                <? echo $academy_head['role'] ?>
+                                <?php echo $academy_head['role'] ?>
                             </p>
                             <p class="sign-date">
-                                <? echo $academy_head['date'] ?>
+                                <?php echo $academy_head['date'] ?>
                             </p>
                         </div>
                     </div>
                 </div>
                 <div class="certificate-showcase-content">
                     <p class="showcase-text">
-                        <? echo $banner_description ?>
+                        <?php echo $banner_description ?>
                     </p>
                     <p class="course-text">
-                        <? echo $want_to_learn ?>
+                        <?php echo $want_to_learn ?>
                     </p>
                     <a class="all-courses" href="<?php echo $courses_link_url; ?>">
-                        <? echo $courses_link_label ?>
+                        <?php echo $courses_link_label ?>
                     </a>
                 </div>
             </div>
         </div>
-        <?
+        <?php
     }
 }

--- a/wp-content/plugins/academy-africa/includes/widgets/feedback.php
+++ b/wp-content/plugins/academy-africa/includes/widgets/feedback.php
@@ -81,11 +81,11 @@ class Academy_Africa_User_Feedback extends \Elementor\Widget_Base
         <div class="feedback">
             <div class="cfa-title">
                 <h4>
-                    <? echo $title ?>
+                    <?php echo $title ?>
                 </h4>
             </div>
             <div class="content">
-                <?
+                <?php
                 if (!empty($feedback)) {
                     foreach ($feedback as $item) {
                         $name = $item["name"];
@@ -99,27 +99,27 @@ class Academy_Africa_User_Feedback extends \Elementor\Widget_Base
                                     <img height="70px" width="70px" src="/wp-content/plugins/academy-africa/includes/assets/images/avatar.png" alt="user" class="avatar">
                                     <div class="name-role">
                                         <p class="name">
-                                            <? echo $name ?>
+                                            <?php echo $name ?>
                                         </p>
                                         <p class="role">
-                                            <? echo $role ?>
+                                            <?php echo $role ?>
                                         </p>
                                         <p class="role">
-                                            <? echo $company ?>
+                                            <?php echo $company ?>
                                         </p>
                                     </div>
                                 </div>
                                 <div class="description">
-                                    <? echo $description ?>
+                                    <?php echo $description ?>
                                 </div>
                             </div>
                         </div>
-                <?
+                <?php
                     }
                 }
                 ?>
             </div>
         </div>
-<?
+<?php
     }
 }

--- a/wp-content/plugins/academy-africa/includes/widgets/footer.php
+++ b/wp-content/plugins/academy-africa/includes/widgets/footer.php
@@ -211,13 +211,13 @@ class Academy_Africa_Footer extends \Elementor\Widget_Base
                     <div class="site-description">
                         <img height="110" width="250" src="<?php echo $image_url ?>" alt=<?php echo get_bloginfo('name'); ?> class="logo">
                         <p class="description" <?php echo $this->get_render_attribute_string('site_description'); ?>>
-                            <? echo $site_description ?>
+                            <?php echo $site_description ?>
                         </p>
                         <div class="footer-connect">
                             <span style="white-space: nowrap;" <?php echo $this->get_render_attribute_string('stay_in_touch_text'); ?>>
-                                <? echo $stay_in_touch_text ?>
+                                <?php echo $stay_in_touch_text ?>
                             </span>
-                            <?
+                            <?php
                             if (!empty($settings['social_media_links'])) {
                                 foreach ($settings['social_media_links'] as $item) {
                                     $link = esc_url($item['link']['url']);
@@ -233,7 +233,7 @@ class Academy_Africa_Footer extends \Elementor\Widget_Base
                 </div>
                 <div class="item">
                     <div class="links">
-                        <?
+                        <?php
                         if (!empty($settings['primary_links'])) {
                             foreach ($settings['primary_links'] as $item) {
                                 $page_link = esc_url($item['page_link']['url']);

--- a/wp-content/plugins/academy-africa/includes/widgets/hero.php
+++ b/wp-content/plugins/academy-africa/includes/widgets/hero.php
@@ -114,10 +114,10 @@ class Academy_Africa_Hero extends \Elementor\Widget_Base
                 <div class="mobile-hidden"></div>
                 <div class="content">
                     <div class="title" <?php echo $this->get_render_attribute_string('title'); ?>>
-                        <? echo $title ?>
+                        <?php echo $title ?>
                     </div>
                     <a class="signup-button" href="<?php echo $sign_up_url; ?>">
-                        <? echo $sign_up_label ?>
+                        <?php echo $sign_up_label ?>
                     </a>
                 </div>
                 <img height="217" alt="mask" class="mask" src="/wp-content/plugins/academy-africa/includes/assets/images/mask.png" />
@@ -125,7 +125,7 @@ class Academy_Africa_Hero extends \Elementor\Widget_Base
             <div class="content-parent">
                 <div class="metrics-content">
                     <div class="metrics">
-                        <?
+                        <?php
                         if (!empty($settings['metrics'])) {
                             foreach ($settings['metrics'] as $item) {
                                 $metric = esc_html($item['metric']);
@@ -133,13 +133,13 @@ class Academy_Africa_Hero extends \Elementor\Widget_Base
                         ?>
                                 <div class="metric">
                                     <h2 class="numbers">
-                                        <? echo $metric ?>
+                                        <?php echo $metric ?>
                                     </h2>
                                     <p class="label">
-                                        <? echo $label ?>
+                                        <?php echo $label ?>
                                     </p>
                                 </div>
-                        <?
+                        <?php
                             }
                         }
                         ?>
@@ -148,6 +148,6 @@ class Academy_Africa_Hero extends \Elementor\Widget_Base
                 <div class="mask"></div>
             </div>
         </div>
-<?
+<?php
     }
 }

--- a/wp-content/plugins/academy-africa/includes/widgets/my_courses.php
+++ b/wp-content/plugins/academy-africa/includes/widgets/my_courses.php
@@ -171,18 +171,18 @@ class Academy_Africa_My_Courses  extends \Elementor\Widget_Base
         <main class="body">
             <div class="sidebar" id="sidebar">
                 <p class="filter-by">
-                    <? echo $filter_by ?>
+                    <?php echo $filter_by ?>
                 </p>
-                <?
+                <?php
                 if (!empty($filter_options)) {
                     foreach ($filter_options as $item) {
                         $title = $item["title"];
                         $options = $item["options"];
                 ?>
                         <p style="margin-top: 40px" class="filter-by-title">
-                            <? echo $title ?>
+                            <?php echo $title ?>
                         </p>
-                        <?
+                        <?php
                         if (!empty($options)) {
                             foreach ($options as $option) {
                         ?>
@@ -191,11 +191,11 @@ class Academy_Africa_My_Courses  extends \Elementor\Widget_Base
                                         <label class="mui-checkbox">
                                             <input type="checkbox">
                                             <span class="checkmark"></span>
-                                            <? echo $option ?>
+                                            <?php echo $option ?>
                                         </label>
                                     </li>
                                 </ul>
-                <?
+                <?php
                             }
                         }
                     }
@@ -212,7 +212,7 @@ class Academy_Africa_My_Courses  extends \Elementor\Widget_Base
                         Complete your courses
                     </p>
                     <div class="content">
-                        <?
+                        <?php
                         if (!empty($incomplete_courses)) {
                             foreach ($incomplete_courses as $course) {
                                 $title = $course['title'];
@@ -222,29 +222,29 @@ class Academy_Africa_My_Courses  extends \Elementor\Widget_Base
                                 $image = $course['image'];
                         ?>
                                 <div class="card">
-                                    <img alt="course-logo" class="logo" src="<? echo $image ?>" />
+                                    <img alt="course-logo" class="logo" src="<?php echo $image ?>" />
                                     <div class="card-content">
                                         <div class="card-title">
                                             <p>
-                                                <? echo $title ?>
+                                                <?php echo $title ?>
                                             </p>
                                         </div>
                                         <p class="provider">
-                                            by <? echo $provider ?>
+                                            by <?php echo $provider ?>
                                         </p>
                                         <p class="lessons-count">
-                                            <? echo $lessons_count ?> lessons
+                                            <?php echo $lessons_count ?> lessons
                                         </p>
                                         <div class="progress-bar">
-                                            <div style="width: <? echo $completed ?>"></div>
+                                            <div style="width: <?php echo $completed ?>"></div>
                                         </div>
                                         <div class="card-footer">
                                             <p>Enrolled</p>
-                                            <p><? echo $completed ?> Completed</p>
+                                            <p><?php echo $completed ?> Completed</p>
                                         </div>
                                     </div>
                                 </div>
-                        <?
+                        <?php
                             }
                         }
                         ?>
@@ -278,7 +278,7 @@ class Academy_Africa_My_Courses  extends \Elementor\Widget_Base
                         Your Certificates
                     </h4>
                     <div class="content">
-                        <?
+                        <?php
                         if (!empty($completed_courses)) {
                             foreach ($completed_courses as $course) {
                                 $title = $course['title'];
@@ -292,14 +292,14 @@ class Academy_Africa_My_Courses  extends \Elementor\Widget_Base
                                     <div class="card-content">
                                         <div class="card-title">
                                             <p>
-                                                <? echo $title ?>
+                                                <?php echo $title ?>
                                             </p>
                                         </div>
                                         <p class="provider">
-                                            by <? echo $provider ?>
+                                            by <?php echo $provider ?>
                                         </p>
                                         <p class="lessons-count">
-                                            <? echo $lessons_count ?> lessons
+                                            <?php echo $lessons_count ?> lessons
                                         </p>
                                         <div class="completed-progress-bar">
                                         </div>
@@ -312,7 +312,7 @@ class Academy_Africa_My_Courses  extends \Elementor\Widget_Base
                                         </div>
                                     </div>
                                 </div>
-                        <?
+                        <?php
                             }
                         }
                         ?>
@@ -343,6 +343,6 @@ class Academy_Africa_My_Courses  extends \Elementor\Widget_Base
                 </section>
             </div>
         </main>
-<?
+<?php
     }
 }

--- a/wp-content/plugins/academy-africa/includes/widgets/partners.php
+++ b/wp-content/plugins/academy-africa/includes/widgets/partners.php
@@ -124,11 +124,11 @@ class Academy_Africa_Partners extends \Elementor\Widget_Base
         <div class="partners">
             <div class="cfa-title">
                 <h4>
-                    <? echo $title ?>
+                    <?php echo $title ?>
                 </h4>
             </div>
             <div class="partner-content">
-                <?
+                <?php
                 if (!empty($our_partners)) {
                     foreach ($our_partners as $partner) {
                         $icon = $partner["icon"];
@@ -136,20 +136,20 @@ class Academy_Africa_Partners extends \Elementor\Widget_Base
                         $url = $partner["url"];
                 ?>
                         <div class="partner">
-                            <a href="<? echo $url ?>">
-                                <img src="<? echo $icon ?>" alt="<? echo $name ?>">
+                            <a href="<?php echo $url ?>">
+                                <img src="<?php echo $icon ?>" alt="<?php echo $name ?>">
                             </a>
                         </div>
-                <?
+                <?php
                     }
                 }
                 ?>
             </div>
         </div>
         <div class="other-partners">
-            <h1 class="other-partners-title"><? echo $other_partners_title ?></h1>
+            <h1 class="other-partners-title"><?php echo $other_partners_title ?></h1>
             <div class="other-partners-content">
-                <?
+                <?php
                 if (!empty($other_partners)) {
                     foreach ($other_partners as $partner) {
                         $icon = $partner["icon"];
@@ -158,15 +158,15 @@ class Academy_Africa_Partners extends \Elementor\Widget_Base
                 ?>
                         <div class="partner-tag">
                             <div class="partner-tag-content">
-                                <? echo $name ?>
+                                <?php echo $name ?>
                             </div>
                         </div>
-                <?
+                <?php
                     }
                 }
                 ?>
             </div>
         </div>
-<?
+<?php
     }
 }

--- a/wp-content/themes/academyAfrica/edit-profile.php
+++ b/wp-content/themes/academyAfrica/edit-profile.php
@@ -101,14 +101,14 @@ if (is_user_logged_in()) {
 ?>
     <main class="profile">
         <h4 class="cfa-title">
-            <? echo $page_title ?>
+            <?php echo $page_title ?>
         </h4>
         <form method="post" action="" enctype="multipart/form-data">
             <label for="avatar" class="avatar-label">
-                <? echo $avatar_label ?>
+                <?php echo $avatar_label ?>
             </label>
             <div class="avatar">
-                <img height="100px" width="100px" style="height: 100px;" src="<? echo $avatar_url ?>" alt="<?php echo esc_attr($current_user->user_firstname); ?>" id="avatar_preview">
+                <img height="100px" width="100px" style="height: 100px;" src="<?php echo $avatar_url ?>" alt="<?php echo esc_attr($current_user->user_firstname); ?>" id="avatar_preview">
                 <button type="button" onclick="document.getElementById('avatar').click()" class="button primary">
                     <input onchange="displayImage(this)" style="display: none;" type="file" name="avatar" id="avatar">
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
@@ -116,42 +116,42 @@ if (is_user_logged_in()) {
                         <path d="M11.3346 5.33333L8.0013 2L4.66797 5.33333" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
                         <path d="M8 2V10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
                     </svg>
-                    <? echo $upload_text ?>
+                    <?php echo $upload_text ?>
                 </button>
             </div>
 
             <p class="my-courses">
                 <a href="/my-courses">
-                    <? echo $view_my_courses ?>
+                    <?php echo $view_my_courses ?>
                 </a>
             </p>
             <p class="form-description">
-                <? echo $form_description ?>
+                <?php echo $form_description ?>
             </p>
             <div class="user-form">
                 <div class="input">
                     <label for="user_firstname">
-                        <? echo $first_name_label ?>*
+                        <?php echo $first_name_label ?>*
                     </label>
-                    <input type="text" name="first_name" required value="<? echo $first_name ?>" id="user_firstname">
+                    <input type="text" name="first_name" required value="<?php echo $first_name ?>" id="user_firstname">
                 </div>
                 <div class="input">
                     <label for="user_lastname">
-                        <? echo $last_name_label ?>*
+                        <?php echo $last_name_label ?>*
                     </label>
-                    <input type="text" name="last_name" required value="<? echo $last_name ?>" id="user_lastname">
+                    <input type="text" name="last_name" required value="<?php echo $last_name ?>" id="user_lastname">
                 </div>
                 <div class="input">
                     <label for="user_email">
-                        <? echo $email_label ?>
+                        <?php echo $email_label ?>
                     </label>
-                    <input type="email" name="user_email" value="<? echo $user_email ?>" id="user_email" disabled>
+                    <input type="email" name="user_email" value="<?php echo $user_email ?>" id="user_email" disabled>
                 </div>
                 <div class="input">
                     <label for="phone">
-                        <? echo $phone_label ?>
+                        <?php echo $phone_label ?>
                     </label>
-                    <select style="width:96px" class="prefix" value="<? echo $prefix ?>" name="prefix" id="prefix">
+                    <select style="width:96px" class="prefix" value="<?php echo $prefix ?>" name="prefix" id="prefix">
                         <?php
                         include_once __DIR__ . '/includes/utils/countries.php';
                         function sort_by_dial_code($a, $b)
@@ -164,7 +164,7 @@ if (is_user_logged_in()) {
                                 $label = $country['flag'] . ' ' . $country['dial_code'];
                                 $selected = $prefix === $country['dial_code'] ? 'selected="selected"' : null;
                         ?>
-                            <option <? echo $selected ?> value="<?php echo $country['dial_code'] ?>">
+                            <option <?php echo $selected ?> value="<?php echo $country['dial_code'] ?>">
                                 <?php echo $label ?>
                             </option>
                         <?php
@@ -179,70 +179,70 @@ if (is_user_logged_in()) {
                         }
                         ?>
                     </select>
-                    <input type="tel" name="phone" value="<? echo $phone ?>" id="phone">
+                    <input type="tel" name="phone" value="<?php echo $phone ?>" id="phone">
                 </div>
                 <div class="input">
                     <label for="city">
-                        <? echo $city_label ?>*
+                        <?php echo $city_label ?>*
                     </label>
-                    <input type="text" name="city" required value="<? echo $city ?>" id="city">
+                    <input type="text" name="city" required value="<?php echo $city ?>" id="city">
                 </div>
 
                 <div class="input">
                     <label for="country">
-                        <? echo $country_label ?>*
+                        <?php echo $country_label ?>*
                     </label>
-                    <input type="text" name="country" id="country" required value="<? echo $_country ?>">
+                    <input type="text" name="country" id="country" required value="<?php echo $_country ?>">
                 </div>
                 <div class="input">
                     <label for="position">
-                        <? echo $position_label ?>
+                        <?php echo $position_label ?>
                     </label>
-                    <input type="text" name="position" value="<? echo $position ?>" id="position">
+                    <input type="text" name="position" value="<?php echo $position ?>" id="position">
                 </div>
                 <div class="input">
                     <label for="company">
-                        <? echo $company_label ?>
+                        <?php echo $company_label ?>
                     </label>
-                    <input type="text" name="company" value="<? echo $company ?>" id="company">
+                    <input type="text" name="company" value="<?php echo $company ?>" id="company">
                 </div>
 
                 <!-- <div class="input">
                     <label for="slack">
-                        <? /*echo $slack_label*/ ?>
+                        <?php /*echo $slack_label*/ ?>
                     </label>
-                    <input type="text" name="slack" value="<? echo $slack ?>" id="slack">
+                    <input type="text" name="slack" value="<?php echo $slack ?>" id="slack">
                 </div> -->
                 <div class="input">
                     <label for="twitter">
-                        <? echo $twitter_label ?>
+                        <?php echo $twitter_label ?>
                     </label>
-                    <input type="url" name="twitter" value="<? echo $twitter ?>" id="twitter">
+                    <input type="url" name="twitter" value="<?php echo $twitter ?>" id="twitter">
                 </div>
                 <div class="input">
                     <label for="facebook">
-                        <? echo $facebook_label ?>
+                        <?php echo $facebook_label ?>
                     </label>
-                    <input type="url" name="facebook" value="<? echo $facebook ?>" id="facebook">
+                    <input type="url" name="facebook" value="<?php echo $facebook ?>" id="facebook">
                 </div>
                 <div class="input">
                     <label for="linked_in">
-                        <? echo $linked_in_label ?>
+                        <?php echo $linked_in_label ?>
                     </label>
-                    <input type="url" name="linked_in" value="<? echo $linked_in ?>" id="linked_in">
+                    <input type="url" name="linked_in" value="<?php echo $linked_in ?>" id="linked_in">
                 </div>
                 <div class="input">
                     <label for="website">
                         Website
                     </label>
-                    <input type="url" name="website" value="<? echo $website ?>" id="website">
+                    <input type="url" name="website" value="<?php echo $website ?>" id="website">
                 </div>
                 <input type="hidden" name="action" value="profile">
                 <div class="bio">
                     <label for="description">
-                        <? echo $bio_label ?>
+                        <?php echo $bio_label ?>
                     </label>
-                    <?
+                    <?php
                     $content = $description;
                     $editor_id = 'description';
                     wp_editor($description, $editor_id, [
@@ -256,44 +256,44 @@ if (is_user_logged_in()) {
 
             <p class="mandatory">
                 *
-                <? echo $mandatory_label ?>
+                <?php echo $mandatory_label ?>
             </p>
             <div class="updates">
                 <p class="receive-updates">
-                    <? echo $receive_updates_label ?>
+                    <?php echo $receive_updates_label ?>
                 </p>
                 <div class="checkbox-group">
                     <ul>
                         <li>
                             <label class="mui-checkbox">
-                                <?
+                                <?php
                                 $checked = in_array("courses", $user_updates) ? 'checked="true"' : "";
                                 ?>
-                                <input type="checkbox" <? echo $checked ?> name="updates[]" value="courses">
+                                <input type="checkbox" <?php echo $checked ?> name="updates[]" value="courses">
                                 <span class="checkmark"></span>
-                                <? echo $new_courses_label ?>
+                                <?php echo $new_courses_label ?>
                             </label>
                         </li>
                         <li>
                             <label class="mui-checkbox">
-                                <?
+                                <?php
                                 $checked = in_array("events", $user_updates) ? 'checked="true"' : "";
                                 ?>
-                                <input type="checkbox" <? echo $checked ?> name="updates[]" value="events">
+                                <input type="checkbox" <?php echo $checked ?> name="updates[]" value="events">
                                 <span class="checkmark"></span>
-                                <? echo $new_events_label ?>
+                                <?php echo $new_events_label ?>
                             </label>
                         </li>
                     </ul>
                 </div>
             </div>
             <h1 class="setting-title">
-                <? echo $settings_title ?>
+                <?php echo $settings_title ?>
             </h1>
             <p class="setting-description">
-                <? echo $settings_description ?>
+                <?php echo $settings_description ?>
             </p>
-            <?
+            <?php
             $args = array(
                 'post_type' => 'network',
                 'posts_per_page' => -1,
@@ -309,30 +309,30 @@ if (is_user_logged_in()) {
                     $join = get_post_meta($network_id, 'join', true)["url"];
             ?>
                     <div class="network">
-                        <img class="img" src="<? echo $image_url ?>" alt="<? echo $network_title ?>">
+                        <img class="img" src="<?php echo $image_url ?>" alt="<?php echo $network_title ?>">
                         <div class="content">
                             <p class="title">
-                                <? echo $network_title ?>
+                                <?php echo $network_title ?>
                             </p>
                             <div class="description">
-                                <? echo $description ?>
+                                <?php echo $description ?>
                             </div>
                             <label class="mui-checkbox">
-                                <?
+                                <?php
                                 $checked = in_array($network_id, $user_networks) ? 'checked="true"' : "";
                                 ?>
-                                <input <? echo $checked ?> type="checkbox" name="networks[]" value="<? echo $network_id ?>">
+                                <input <?php echo $checked ?> type="checkbox" name="networks[]" value="<?php echo $network_id ?>">
                                 <span class="checkmark"></span>
-                                <? echo $membership_label ?>
+                                <?php echo $membership_label ?>
                             </label>
-                            <a target="_blank" href="<? echo $join ?>">
+                            <a target="_blank" href="<?php echo $join ?>">
                                 <button type="button" class="primary button">
                                     Join
                                 </button>
                             </a>
                         </div>
                     </div>
-            <?
+            <?php
                 }
                 wp_reset_query();
             }
@@ -344,7 +344,7 @@ if (is_user_logged_in()) {
                         <path d="M11.3346 14.4993V9.16602H4.66797V14.4993" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
                         <path d="M4.66797 2.5V5.83333H10.0013" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
                     </svg>
-                    <? echo $save_changes_label ?>
+                    <?php echo $save_changes_label ?>
                 </button>
             </div>
         </form>

--- a/wp-content/themes/academyAfrica/functions.php
+++ b/wp-content/themes/academyAfrica/functions.php
@@ -493,9 +493,9 @@ function set_global_error($message = "An error occured")
 {
 ?>
     <script>
-        window.error = <? echo json_encode($message) ?>
+        window.error = <?php echo json_encode($message) ?>
     </script>
-<?
+<?php
 }
 function render_inactive($render)
 {

--- a/wp-content/themes/academyAfrica/includes/functions/password_reset.php
+++ b/wp-content/themes/academyAfrica/includes/functions/password_reset.php
@@ -1,4 +1,4 @@
-<?
+<?php
 function password_reset($user_email){
   // Check if the email address is valid
   if ( !is_email($user_email) ) {

--- a/wp-content/themes/academyAfrica/includes/functions/register.php
+++ b/wp-content/themes/academyAfrica/includes/functions/register.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 function check_register_action()
 {

--- a/wp-content/themes/academyAfrica/includes/widgets/about.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/about.php
@@ -66,6 +66,6 @@ class Academy_Africa_About_Section extends \Elementor\Widget_Base
                 <?php echo $content; ?>
             </div>
         </div>
-<?
+<?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/all_courses.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/all_courses.php
@@ -277,7 +277,7 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
             <div class="courses-main" id="all-courses">
                 <section class="course-grid">
                     <h4 class="cfa-title">
-                        <? echo $courses_title ?>
+                        <?php echo $courses_title ?>
                     </h4>
                     <div class="filter-by-language">
                         <div class="label">
@@ -293,7 +293,7 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
                             foreach ($languages as $language_code => $language_name) {
 
                             ?>
-                                <button id="<? echo $language_code ?>" class="button medium ld-button"
+                                <button id="<?php echo $language_code ?>" class="button medium ld-button"
                                     onclick="filterByLanguage('<?php echo $language_code; ?>')">
                                     <?php echo $language_name; ?>
                                 </button>
@@ -314,15 +314,15 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
                     <div class="filter-section">
                         <div class="sort">
                             <div class="label">
-                                <? echo $sort_by ?>
+                                <?php echo $sort_by ?>
                             </div>
                             <select name="sort" id="courses-sort" class="select" onchange="sortCourses(this)">
-                                <?
+                                <?php
                                 foreach ($sort_options as $key => $option) {
                                     $selected = $sort == $key ? "selected" : "";
                                 ?>
-                                    <option <? echo $selected ?> value="<? echo $key ?>"><? echo $option["name"] ?></option>
-                                <?
+                                    <option <?php echo $selected ?> value="<?php echo $key ?>"><?php echo $option["name"] ?></option>
+                                <?php
                                 }
                                 ?>
                             </select>
@@ -370,7 +370,7 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
                         });
                     </script>
                     <div class="course-list">
-                        <?
+                        <?php
                         if (!empty($courses)) {
                             foreach ($courses as $course) {
                                 $course_title = get_the_title($course);
@@ -403,12 +403,12 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
                                         'students' => $students
                                     ]
                                 ); ?>
-                        <?
+                        <?php
                             }
                         }
                         ?>
                     </div>
-                    <?
+                    <?php
                     if ($has_pagination) {
                     ?>
                         <hr class="divider">
@@ -417,52 +417,52 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
                                 View All
                             </button>
                             <ul class="pagination">
-                                <?
+                                <?php
                                 if ($current_page > 1) {
                                 ?>
                                     <li class="page-item">
-                                        <div class="page-link" onclick="paginateCourses(<? echo $current_page - 1 ?>)">
+                                        <div class="page-link" onclick="paginateCourses(<?php echo $current_page - 1 ?>)">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
                                                 <path d="M10 12L6 8L10 4" stroke="#616582" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
                                             </svg>
                                         </div>
                                     </li>
-                                    <?
+                                    <?php
                                 }
                                 for ($i = 1; $i <= $no_of_pages; $i++) {
                                     if ($i == $current_page) {
                                     ?>
                                         <li class="page-item active">
                                             <div class="page-link">
-                                                <? echo $i ?>
+                                                <?php echo $i ?>
                                             </div>
                                         </li>
-                                    <?
+                                    <?php
                                     } else {
                                     ?>
                                         <li class="page-item">
-                                            <div class="page-link" onclick="paginateCourses(<? echo $i ?>)">
-                                                <? echo $i ?>
+                                            <div class="page-link" onclick="paginateCourses(<?php echo $i ?>)">
+                                                <?php echo $i ?>
                                             </div>
                                         </li>
-                                    <?
+                                    <?php
                                     }
                                 }
                                 if ($current_page < $no_of_pages) {
                                     ?>
                                     <li class="page-item">
-                                        <div class="page-link" onclick="paginateCourses(<? echo $current_page + 1 ?>)">
+                                        <div class="page-link" onclick="paginateCourses(<?php echo $current_page + 1 ?>)">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
                                                 <path d="M6 12L10 8L6 4" stroke="#616582" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
                                             </svg>
                                         </div>
                                     </li>
-                                <?
+                                <?php
                                 }
                                 ?>
                             </ul>
                         </div>
-                    <?
+                    <?php
                     }
                     ?>
                 </section>
@@ -470,34 +470,34 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
                 ?>
                     <div class="career-dev">
                         <div class="title">
-                            <? echo $pathway_title ?>
+                            <?php echo $pathway_title ?>
                         </div>
                         <div class="body">
                             <div class="content">
                                 <div class="text">
-                                    <? echo $pathway_description ?>
+                                    <?php echo $pathway_description ?>
                                 </div>
                                 <div class="cta">
-                                    <a href="<? echo $pathway_button_link ?>" class="button primary medium">
-                                        <? echo $pathway_button_text ?>
+                                    <a href="<?php echo $pathway_button_link ?>" class="button primary medium">
+                                        <?php echo $pathway_button_text ?>
                                         <i class="fas fa-arrow-right"></i>
                                     </a>
                                 </div>
                             </div>
                             <div class="sample-course">
-                                <a class="pathway-link" href="<? echo get_permalink($pathway) ?>">
+                                <a class="pathway-link" href="<?php echo get_permalink($pathway) ?>">
                                     <div class="card">
                                         <div class="course-card-pattern">
                                             <div class="icon">
-                                                <img src="<?php echo get_the_post_thumbnail_url($pathway); ?>" alt="<? echo $pathway->post_title ?>" />
+                                                <img src="<?php echo get_the_post_thumbnail_url($pathway); ?>" alt="<?php echo $pathway->post_title ?>" />
                                             </div>
                                         </div>
                                         <div class="pathway-card-content">
                                             <p class="pathway-name">
-                                                <? echo $pathway->post_title ?>
+                                                <?php echo $pathway->post_title ?>
                                             </p>
                                             <p class="course-count">
-                                                <? echo count($pathway_courses) . ' Courses' ?>
+                                                <?php echo count($pathway_courses) . ' Courses' ?>
                                             </p>
                                         </div>
                                     </div>
@@ -505,11 +505,11 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
                             </div>
                         </div>
                     </div>
-                <?
+                <?php
                 }
                 ?>
             </div>
         </main>
-<?
+<?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/connect_and_collaborate.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/connect_and_collaborate.php
@@ -102,14 +102,14 @@ class Academy_Africa_Connect_and_Collaborate extends \Elementor\Widget_Base
             <div class="title-wrapper">
                 <div class="cfa-title">
                     <h4>
-                        <? echo $title ?>
+                        <?php echo $title ?>
                     </h4>
                 </div>
             </div>
             <div class="content">
                 <div class="share-text">
                     <p class="share">
-                        <? echo $share_text ?>
+                        <?php echo $share_text ?>
                     </p>
                 </div>
                 <div class="center africa">
@@ -119,18 +119,18 @@ class Academy_Africa_Connect_and_Collaborate extends \Elementor\Widget_Base
                 <div class="join-slack">
                     <div class="share-text">
                         <p class="share">
-                            <? echo $share_text ?>
+                            <?php echo $share_text ?>
                         </p>
                     </div>
                     <p class="become-a-member">
-                        <? echo $become_a_member_text ?>
+                        <?php echo $become_a_member_text ?>
                     </p>
-                    <a href="<? echo $join_us_url ?>" class="button primary large">
-                        <? echo $join_us_on_slack ?>
+                    <a href="<?php echo $join_us_url ?>" class="button primary large">
+                        <?php echo $join_us_on_slack ?>
                     </a>
                 </div>
             </div>
         </div>
-        <?
+        <?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/events.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/events.php
@@ -350,9 +350,9 @@ class Academy_Africa_Events  extends \Elementor\Widget_Base
             <aside class="filter-sidebar">
                 <div class="sidebar" id="sidebar">
                     <p class="filter-by">
-                        <? echo $filter_by ?>
+                        <?php echo $filter_by ?>
                     </p>
-                    <?
+                    <?php
                     if (!empty($filter_options)) {
                         foreach ($filter_options as $item) {
                             $title = $item["title"];
@@ -360,30 +360,30 @@ class Academy_Africa_Events  extends \Elementor\Widget_Base
                             $option_name = $item["name"];
                     ?>
                             <p class="filter-by-title">
-                                <? echo $title ?>
+                                <?php echo $title ?>
                             </p>
-                            <?
+                            <?php
                             if (!empty($options)) {
                             ?>
                                 <ul>
 
-                                    <?
+                                    <?php
                                     foreach ($options as $option => $opt_value) {
                                     ?>
 
                                         <li>
                                             <label class="mui-checkbox">
-                                                <input type="checkbox" name="<? echo $option_name . '-' . $opt_value ?>" onclick="onChangeCheckBox(this, '<? echo $option_name ?>','<? echo $opt_value ?>', true)">
+                                                <input type="checkbox" name="<?php echo $option_name . '-' . $opt_value ?>" onclick="onChangeCheckBox(this, '<?php echo $option_name ?>','<?php echo $opt_value ?>', true)">
                                                 <span class="checkmark"></span>
-                                                <? echo $option ?>
+                                                <?php echo $option ?>
                                             </label>
                                         </li>
 
-                                    <?
+                                    <?php
                                     }
                                     ?>
                                 </ul>
-                    <?
+                    <?php
                             }
                         }
                     }
@@ -409,49 +409,49 @@ class Academy_Africa_Events  extends \Elementor\Widget_Base
 
             <section class="events-content">
                 <div class="cfa-title" <?php echo $this->get_render_attribute_string('page_title'); ?>>
-                    <? echo $page_title ?>
+                    <?php echo $page_title ?>
                 </div>
                 <div id="filters" class="events-mobile-filters">
                     <div>
                         <div class="filters">
                             <div class="close-filters">
                                 <h1 class="filter-by">
-                                    <? echo $filter_by ?>
+                                    <?php echo $filter_by ?>
                                 </h1>
                             </div>
-                            <?
+                            <?php
                             if (!empty($filter_options)) {
                                 foreach ($filter_options as $item) {
                                     $title = $item["title"];
                             ?>
                                     <div class="accordion-parent">
-                                        <button class="accordion"><? echo $title ?></button>
-                                        <?
+                                        <button class="accordion"><?php echo $title ?></button>
+                                        <?php
                                         $options = $item["options"];
                                         $option_name = $item["name"];
                                         if (!empty($options)) {
                                         ?><div class="panel">
-                                                <ul><?
+                                                <ul><?php
                                                     foreach ($options as $option => $opt_value) {
                                                     ?>
 
                                                         <li>
                                                             <label class="mui-checkbox">
-                                                                <input type="checkbox" name="<? echo $option_name . '-' . $opt_value ?>" onclick="onChangeCheckBox(this, '<? echo $option_name ?>','<? echo $opt_value ?>')">
+                                                                <input type="checkbox" name="<?php echo $option_name . '-' . $opt_value ?>" onclick="onChangeCheckBox(this, '<?php echo $option_name ?>','<?php echo $opt_value ?>')">
                                                                 <span class="checkmark"></span>
-                                                                <? echo $option ?>
+                                                                <?php echo $option ?>
                                                             </label>
                                                         </li>
 
-                                                    <?
+                                                    <?php
                                                     }
                                                     ?>
                                                 </ul>
                                             </div>
-                                        <?
+                                        <?php
                                         }
                                         ?>
-                                    </div><?
+                                    </div><?php
                                         }
                                     }
                                             ?>
@@ -480,12 +480,12 @@ class Academy_Africa_Events  extends \Elementor\Widget_Base
                     </div>
                 </div>
                 <div class="selected-filters" id="selected-filters"></div>
-                <? if (!empty($upcoming_events)) { ?>
+                <?php if (!empty($upcoming_events)) { ?>
                     <div class="section-title" <?php echo $this->get_render_attribute_string('upcoming_events_title'); ?>>
-                        <? echo $upcoming_events_title ?>
+                        <?php echo $upcoming_events_title ?>
                     </div>
                     <div class="content">
-                        <?
+                        <?php
 
                         foreach ($upcoming_events as $event) {
                             $image = $event["image"];
@@ -497,37 +497,37 @@ class Academy_Africa_Events  extends \Elementor\Widget_Base
                             $time = $event["time"];
                             $is_virtual = $event["is_virtual"];
                         ?>
-                            <a href="<? echo $event["post_url"] ?>">
+                            <a href="<?php echo $event["post_url"] ?>">
                                 <div class="card">
-                                    <img width="100%" src="<? echo $image ?>" alt="<? echo $title ?>">
+                                    <img width="100%" src="<?php echo $image ?>" alt="<?php echo $title ?>">
 
                                     <p class="event-title">
-                                        <? echo $title ?>
+                                        <?php echo $title ?>
                                     </p>
                                     <p class="speaker-name">
-                                        <? echo $speaker ?>
+                                        <?php echo $speaker ?>
                                     </p>
                                     <div class="flex-between date-and-language">
                                         <p class="date">
-                                            <? echo $date ?>
+                                            <?php echo $date ?>
                                         </p>
                                         <p class="language">
-                                            <? echo $language ?>
+                                            <?php echo $language ?>
                                         </p>
 
                                     </div>
                                     <div class="flex-between time-and-country">
                                         <p class="time">
-                                            <? echo $time ?>
+                                            <?php echo $time ?>
                                         </p>
                                         <p class="country">
-                                            <? echo $is_virtual ?>
+                                            <?php echo $is_virtual ?>
                                         </p>
                                     </div>
                                 </div>
                             </a>
 
-                        <?
+                        <?php
                         }
                         ?>
                     </div>
@@ -544,19 +544,19 @@ class Academy_Africa_Events  extends \Elementor\Widget_Base
                                 </a>
                             </li>
 
-                            <?
+                            <?php
                             $upcoming_page_param = $this->get_query_param('upcoming_page');
                             $current = !empty($upcoming_page_param) ? $upcoming_page_param[0] : "1";
                             ?>
                             <!-- Page links -->
                             <?php for ($i = 1; $i <= $upcoming_pagination['total_pages']; $i++) : ?>
-                                <?
+                                <?php
                                 $current_url_params = $_GET;
                                 $current_url_params["upcoming_page"] = $i;
                                 $new_url = add_query_arg($current_url_params, home_url($_SERVER['REQUEST_URI']));
                                 $cls = intval($current) === $i ? "active" : "";
                                 ?>
-                                <li class="page-item <? echo $cls ?>"><a class="page-link" href="<? echo $new_url ?>"><?php echo $i; ?></a></li>
+                                <li class="page-item <?php echo $cls ?>"><a class="page-link" href="<?php echo $new_url ?>"><?php echo $i; ?></a></li>
                             <?php endfor; ?>
 
                             <!-- Next page link -->
@@ -570,16 +570,16 @@ class Academy_Africa_Events  extends \Elementor\Widget_Base
 
                         </ul>
                     </div>
-                <?
+                <?php
                 }
                 if (!empty($previous_events)) {
 
                 ?>
                     <div class="section-title" <?php echo $this->get_render_attribute_string('previous_events_title'); ?>>
-                        <? echo $previous_events_title ?>
+                        <?php echo $previous_events_title ?>
                     </div>
                     <div class="content">
-                        <?
+                        <?php
                         foreach ($previous_events as $event) {
                             $image = $event["image"];
                             $title = $event["title"];
@@ -590,36 +590,36 @@ class Academy_Africa_Events  extends \Elementor\Widget_Base
                             $time = $event["time"];
                             $is_virtual = $event["is_virtual"];
                         ?>
-                            <a href="<? echo $event["post_url"] ?>">
+                            <a href="<?php echo $event["post_url"] ?>">
                                 <div class="card">
-                                    <img width="100%" src="<? echo $image ?>" alt="<? echo $title ?>">
+                                    <img width="100%" src="<?php echo $image ?>" alt="<?php echo $title ?>">
 
                                     <p class="event-title">
-                                        <? echo $title ?>
+                                        <?php echo $title ?>
                                     </p>
                                     <p class="speaker-name">
-                                        <? echo $speaker ?>
+                                        <?php echo $speaker ?>
                                     </p>
                                     <div class="flex-between date-and-language">
                                         <p class="date">
-                                            <? echo $date ?>
+                                            <?php echo $date ?>
                                         </p>
                                         <p class="language">
-                                            <? echo $language ?>
+                                            <?php echo $language ?>
                                         </p>
 
                                     </div>
                                     <div class="flex-between time-and-country">
                                         <p class="time">
-                                            <? echo $time ?>
+                                            <?php echo $time ?>
                                         </p>
                                         <p class="country">
-                                            <? echo $is_virtual ?>
+                                            <?php echo $is_virtual ?>
                                         </p>
                                     </div>
                                 </div>
                             </a>
-                        <?
+                        <?php
                         }
 
                         ?>
@@ -638,18 +638,18 @@ class Academy_Africa_Events  extends \Elementor\Widget_Base
                             </li>
 
                             <!-- Page links -->
-                            <?
+                            <?php
                             $previous_page_param = $this->get_query_param('previous_events_page');
                             $current = !empty($previous_page_param) ? $previous_page_param[0] : "1";
                             ?>
                             <?php for ($i = 1; $i <= $previous_pagination['total_pages']; $i++) : ?>
-                                <?
+                                <?php
                                 $current_url_params = $_GET;
                                 $current_url_params["previous_events_page"] = $i;
                                 $new_url = add_query_arg($current_url_params, home_url($_SERVER['REQUEST_URI']));
                                 $cls = intval($current) === $i ? "active" : "";
                                 ?>
-                                <li class="page-item <? echo $cls ?>"><a class="page-link" href="<? echo $new_url ?>"><?php echo $i; ?></a></li>
+                                <li class="page-item <?php echo $cls ?>"><a class="page-link" href="<?php echo $new_url ?>"><?php echo $i; ?></a></li>
                             <?php endfor; ?>
 
                             <!-- Next page link -->
@@ -663,11 +663,11 @@ class Academy_Africa_Events  extends \Elementor\Widget_Base
 
                         </ul>
                     </div>
-                <?
+                <?php
                 }
                 ?>
             </section>
         </main>
-<?
+<?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/faq.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/faq.php
@@ -105,6 +105,6 @@ class Academy_Africa_FAQ  extends \Elementor\Widget_Base
             }
             ?>
         </div>
-<?
+<?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/featured_courses.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/featured_courses.php
@@ -254,7 +254,7 @@ class Academy_Africa_Featured_Courses extends \Elementor\Widget_Base
                     </div>
                 </div>
                 <div class="featured-course-list">
-                    <?
+                    <?php
                     if (!empty($courses)) {
                         foreach ($courses as $course) {
                             $course_title = get_the_title($course);
@@ -280,7 +280,7 @@ class Academy_Africa_Featured_Courses extends \Elementor\Widget_Base
                                     'students' => $students
                                 ]
                             ); ?>
-                            <?
+                            <?php
                         }
                     }
                     ?>
@@ -296,15 +296,15 @@ class Academy_Africa_Featured_Courses extends \Elementor\Widget_Base
                                 </p>
                             </div>
                             <p class="showcase-text">
-                                <? echo $certificate_cta_description ?>
+                                <?php echo $certificate_cta_description ?>
                             </p>
                             <a class="button primary large all-courses" href="<?php echo $courses_link['url']; ?>">
-                                <? echo $courses_link_label; ?>
+                                <?php echo $courses_link_label; ?>
                                 <i class="fa-solid fa-chevron-right icon"></i>
                             </a>
                         </div>
             </div>
         </div>
-        <?
+        <?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/feedback.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/feedback.php
@@ -132,11 +132,11 @@ class Academy_Africa_User_Feedback extends \Elementor\Widget_Base
         <div class="feedback">
             <div class="title">
                 <h4 class="cfa-title">
-                    <? echo $title ?>
+                    <?php echo $title ?>
                 </h4>
             </div>
             <div class="content">
-                <?
+                <?php
                 if (!empty($feedback)) {
                     foreach ($feedback as $item) {
                         $name = $item["name"];
@@ -148,30 +148,30 @@ class Academy_Africa_User_Feedback extends \Elementor\Widget_Base
                         <div class="card">
                             <div class="content-card">
                                 <div class="user">
-                                    <img src="<? echo $logo ?>" alt="user" class="avatar">
+                                    <img src="<?php echo $logo ?>" alt="user" class="avatar">
                                     <div class="name-role">
                                         <p class="name">
-                                            <? echo $name ?>
+                                            <?php echo $name ?>
                                         </p>
                                         <p class="role">
-                                            <? echo $role ?>
+                                            <?php echo $role ?>
                                         </p>
                                         <p class="role">
-                                            <? echo $company ?>
+                                            <?php echo $company ?>
                                         </p>
                                     </div>
                                 </div>
                                 <div class="description">
-                                    <? echo $description ?>
+                                    <?php echo $description ?>
                                 </div>
                             </div>
                         </div>
-                <?
+                <?php
                     }
                 }
                 ?>
             </div>
         </div>
-<?
+<?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/header.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/header.php
@@ -132,6 +132,6 @@ class Academy_Africa_Header_Section extends \Elementor\Widget_Base
                     </div>
             </div>
         </div>
-<?
+<?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/hero.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/hero.php
@@ -154,7 +154,7 @@ class Academy_Africa_Hero extends \Elementor\Widget_Base
             'label' => 'Members'
         ]);
 ?>
-        <?
+        <?php
         ?>
         <div class="hero">
             <div class="background-image"></div>
@@ -162,22 +162,22 @@ class Academy_Africa_Hero extends \Elementor\Widget_Base
                 <div class="content">
                     <div class="title">
                         <div class="cfa-title" <?php echo $this->get_render_attribute_string('title'); ?>>
-                            <? echo $title ?>
+                            <?php echo $title ?>
                         </div>
                     </div>
-                    <?
+                    <?php
                     if (!is_user_logged_in()) {
                     ?>
                         <button class="button cta large signup-button" onclick="register()">
-                            <? echo $sign_up_label ?>
+                            <?php echo $sign_up_label ?>
                         </button>
-                    <?
+                    <?php
                     }
                     ?>
                 </div>
                 <div class="metrics-content">
                     <div class="metrics">
-                        <?
+                        <?php
                         if (!empty($metrics)) {
                             foreach ($metrics as $item) {
                                 $metric = esc_html($item['metric']);
@@ -185,13 +185,13 @@ class Academy_Africa_Hero extends \Elementor\Widget_Base
                         ?>
                                 <div class="metric">
                                     <h2 class="numbers">
-                                        <? echo $metric ?>
+                                        <?php echo $metric ?>
                                     </h2>
                                     <p class="label">
-                                        <? echo $label ?>
+                                        <?php echo $label ?>
                                     </p>
                                 </div>
-                        <?
+                        <?php
                             }
                         }
                         ?>
@@ -207,6 +207,6 @@ class Academy_Africa_Hero extends \Elementor\Widget_Base
                 }
             </script>
         </div>
-<?
+<?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/home_learning_pathways.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/home_learning_pathways.php
@@ -146,14 +146,14 @@ class Academy_Africa_Home_Learning_Pathways  extends \Elementor\Widget_Base
             <section class="learning-pathways home-learning-pathways">
                 <div class="title">
                     <h4 class="cfa-title">
-                        <? echo $pathway_title ?>
+                        <?php echo $pathway_title ?>
                     </h4>
                 </div>
                 <p class="description">
-                    <? echo $pathway_description ?>
+                    <?php echo $pathway_description ?>
                 </p>
                 <div class="content">
-                    <?
+                    <?php
                     if (!empty($learning_pathways)) {
                         foreach ($learning_pathways as $pathway) {
                             $pathway_name = $pathway["title"];
@@ -162,39 +162,39 @@ class Academy_Africa_Home_Learning_Pathways  extends \Elementor\Widget_Base
                             $pathway_courses = $pathway["courses"];
                             $pathway_link = get_permalink($pathway["id"]);
                     ?>
-                            <a href="<? echo $pathway_link ?>" class="pathway-link">
+                            <a href="<?php echo $pathway_link ?>" class="pathway-link">
                                 <div class="card">
                                     <div class="course-card-pattern">
                                         <div class="icon">
-                                            <img src="<? echo $pathway_icon ?>" alt="sample-icon">
+                                            <img src="<?php echo $pathway_icon ?>" alt="sample-icon">
                                         </div>
                                     </div>
                                     <div class="pathway-card-content">
                                         <div>
                                             <p class="pathway-name">
-                                                <? echo $pathway_name ?>
+                                                <?php echo $pathway_name ?>
                                             </p>
                                             <p class="pathway-description">
-                                                <? echo wp_trim_words($pathway_desc, 20, '...') ?>
+                                                <?php echo wp_trim_words($pathway_desc, 20, '...') ?>
                                             </p>
                                         </div>
                                         <p class="course-count">
-                                            <? echo count($pathway_courses) . ' ' . $courses_count ?>
+                                            <?php echo count($pathway_courses) . ' ' . $courses_count ?>
                                         </p>
                                     </div>
                                 </div>
                             </a>
-                    <?
+                    <?php
                         }
                     }
                     ?>
                     <div class="pathway-card card">
                         <div class="pathway-cta">
                             <p class="pathway-cta-description">
-                                <? echo $pathway_cta_description ?>
+                                <?php echo $pathway_cta_description ?>
                             </p>
-                            <a href="<? echo $pathway_cta_link['url'] ?>" class="button primary large all-courses">
-                                <? echo $pathway_cta_link_text ?>
+                            <a href="<?php echo $pathway_cta_link['url'] ?>" class="button primary large all-courses">
+                                <?php echo $pathway_cta_link_text ?>
                                 <i class="fa-solid fa-chevron-right icon"></i>
                             </a>
                         </div>
@@ -203,6 +203,6 @@ class Academy_Africa_Home_Learning_Pathways  extends \Elementor\Widget_Base
                 </div>
             </section>
         </main>
-<?
+<?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/join_our_slack.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/join_our_slack.php
@@ -115,6 +115,6 @@ class Academy_Africa_Join_Our_Slack extends \Elementor\Widget_Base
                 </script>
             </div>
         </div>
-<?
+<?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/learning_pathways.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/learning_pathways.php
@@ -162,14 +162,14 @@ class Academy_Africa_Learning_Pathways  extends \Elementor\Widget_Base
                 <section class="learning-pathways">
                     <div class="title">
                         <h4 class="cfa-title">
-                            <? echo $pathway_title ?>
+                            <?php echo $pathway_title ?>
                         </h4>
                     </div>
                     <p class="description">
-                        <? echo $pathway_description ?>
+                        <?php echo $pathway_description ?>
                     </p>
                     <div class="content">
-                        <?
+                        <?php
 
                         if (!empty($learning_pathways)) {
                             foreach ($learning_pathways as $pathway) {
@@ -179,35 +179,35 @@ class Academy_Africa_Learning_Pathways  extends \Elementor\Widget_Base
                                 $pathway_courses = $pathway["courses"];
                                 $pathway_link = get_permalink($pathway["id"]);
                         ?>
-                                <a href="<? echo $pathway_link ?>" class="pathway-link">
+                                <a href="<?php echo $pathway_link ?>" class="pathway-link">
                                     <div class="card">
                                         <div class="course-card-pattern">
                                             <div class="icon">
-                                                <img src="<? echo $pathway_icon ?>" alt="sample-icon">
+                                                <img src="<?php echo $pathway_icon ?>" alt="sample-icon">
                                             </div>
                                         </div>
                                         <div class="pathway-card-content">
                                             <div>
                                                 <p class="pathway-name">
-                                                    <? echo $pathway_name ?>
+                                                    <?php echo $pathway_name ?>
                                                 </p>
                                                 <p class="pathway-description">
-                                                    <? echo wp_trim_words($pathway_desc, 20, '...') ?>
+                                                    <?php echo wp_trim_words($pathway_desc, 20, '...') ?>
                                                 </p>
                                             </div>
 
                                             <p class="course-count">
-                                                <? echo count($pathway_courses) . ' ' . $courses_count ?>
+                                                <?php echo count($pathway_courses) . ' ' . $courses_count ?>
                                             </p>
                                         </div>
                                     </div>
                                 </a>
-                        <?
+                        <?php
                             }
                         }
                         ?>
                     </div>
-                    <?
+                    <?php
                     if ($has_pagination) {
                     ?>
                         <hr class="divider">
@@ -216,57 +216,57 @@ class Academy_Africa_Learning_Pathways  extends \Elementor\Widget_Base
                                 View All
                             </a>
                             <ul class="pagination">
-                                <?
+                                <?php
                                 if ($current_page > 1) {
                                 ?>
                                     <li class="page-item">
-                                        <div class="page-link" onclick="paginateLearningPath(<? echo $current_page - 1 ?>)">
+                                        <div class="page-link" onclick="paginateLearningPath(<?php echo $current_page - 1 ?>)">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
                                                 <path d="M10 12L6 8L10 4" stroke="#616582" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
                                             </svg>
                                         </div>
                                     </li>
-                                    <?
+                                    <?php
                                 }
                                 for ($i = 1; $i <= $total_pages; $i++) {
                                     if ($i == $current_page) {
                                     ?>
                                         <li class="page-item active">
                                             <div class="page-link">
-                                                <? echo $i ?>
+                                                <?php echo $i ?>
                                             </div>
                                         </li>
-                                    <?
+                                    <?php
                                     } else {
                                     ?>
                                         <li class="page-item">
-                                            <div class="page-link" onclick="paginateLearningPath(<? echo $i ?>)">
-                                                <? echo $i ?>
+                                            <div class="page-link" onclick="paginateLearningPath(<?php echo $i ?>)">
+                                                <?php echo $i ?>
                                             </div>
                                         </li>
-                                    <?
+                                    <?php
                                     }
                                 }
                                 if ($current_page < $total_pages) {
                                     ?>
                                     <li class="page-item">
-                                        <div class="page-link" onclick="paginateLearningPath(<? echo $current_page + 1 ?>)">
+                                        <div class="page-link" onclick="paginateLearningPath(<?php echo $current_page + 1 ?>)">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
                                                 <path d="M6 12L10 8L6 4" stroke="#616582" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
                                             </svg>
                                         </div>
                                     </li>
-                                <?
+                                <?php
                                 }
                                 ?>
                             </ul>
                         </div>
-                    <?
+                    <?php
                     }
                     ?>
                 </section>
             </div>
         </main>
-<?
+<?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/my_courses.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/my_courses.php
@@ -187,7 +187,7 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                 <section class="incomplete-courses">
                     <h4 class="cfa-title">
                         Welcome <strong style="text-transform: capitalize;">
-                            <? echo $current_user->display_name; ?>
+                            <?php echo $current_user->display_name; ?>
                         </strong>
                     </h4>
                     <div class="filter-by-language">
@@ -205,7 +205,7 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                             foreach ($languages as $language_code => $language_name) {
 
                             ?>
-                                <button id="<? echo $language_code ?>" class="button medium ld-button"
+                                <button id="<?php echo $language_code ?>" class="button medium ld-button"
                                     onclick="filterByLanguage('<?php echo $language_code; ?>')">
                                     <?php echo $language_name; ?>
                                 </button>
@@ -227,27 +227,27 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                     <div class="filter-section">
                         <div class="sort">
                             <div class="label">
-                                <? echo $sort_by ?>
+                                <?php echo $sort_by ?>
                             </div>
                             <select name="sort" id="courses-sort" class="select" onchange="sortCourses(this)">
-                                <?
+                                <?php
                                 foreach ($sort_options as $key => $option) {
                                     $selected = $sort == $key ? "selected" : "";
                                 ?>
-                                    <option <? echo $selected ?> value="<? echo $key ?>"><? echo $option["name"] ?></option>
-                                <?
+                                    <option <?php echo $selected ?> value="<?php echo $key ?>"><?php echo $option["name"] ?></option>
+                                <?php
                                 }
                                 ?>
                             </select>
                         </div>
                     </div>
-                    <? if (!empty($enrolled)) {
+                    <?php if (!empty($enrolled)) {
                     ?>
                         <p class="description">
                             Complete your courses
                         </p>
                         <div class="content">
-                            <?
+                            <?php
                             foreach ($enrolled as $er) {
                                 $course_id = $er->post_id;
                                 $course = get_post($course_id);
@@ -271,38 +271,38 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                                 $lessons_count = $total_steps;
 
                             ?>
-                                <a href="<? echo $course_link ?>">
-                                    <div id="<? echo $course_id ?>" class="card">
+                                <a href="<?php echo $course_link ?>">
+                                    <div id="<?php echo $course_id ?>" class="card">
                                         <div class="course-card-pattern">
-                                            <img src="<? echo $image ?>" alt="course-thumbnail">
+                                            <img src="<?php echo $image ?>" alt="course-thumbnail">
                                         </div>
                                         <div class="card-content">
                                             <div class="card-title">
                                                 <p>
-                                                    <? echo $title ?>
+                                                    <?php echo $title ?>
                                                 </p>
                                             </div>
                                             <p class="provider">
                                                 by
-                                                <? echo $provider ?>
+                                                <?php echo $provider ?>
                                             </p>
                                             <p class="lessons-count">
-                                                <? echo $lessons_count ?> lessons
+                                                <?php echo $lessons_count ?> lessons
                                             </p>
                                             <div class="progress-bar">
-                                                <div style="width: <? echo $completed ?>"></div>
+                                                <div style="width: <?php echo $completed ?>"></div>
                                             </div>
                                             <div class="card-footer">
                                                 <p>Enrolled</p>
                                                 <p>
-                                                    <? echo $completed ?> Completed
+                                                    <?php echo $completed ?> Completed
                                                 </p>
                                             </div>
                                         </div>
                                     </div>
                                 </a>
 
-                            <?
+                            <?php
                             }
 
                             ?>
@@ -320,7 +320,7 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                                     </a>
                                 </li>
 
-                                <?
+                                <?php
                                 $current_url_params = $_GET;
                                 $current_page = isset($current_url_params["courses_page"]) ? (int) $current_url_params["courses_page"] : 1;
                                 $next_page = $current_page + 1;
@@ -329,20 +329,20 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                                 $next_2 = $next_page + 2;
                                 ?>
                                 <?php for ($i = 1; $i <= $my_courses_pagination['total_pages']; $i++) : ?>
-                                    <?
+                                    <?php
                                     $current_url_params["courses_page"] = $i;
                                     $new_url = add_query_arg($current_url_params, home_url($_SERVER['REQUEST_URI']));
                                     if ($i === $previous_page || $i === $next_page || $i === $my_courses_pagination['total_pages'] || $i === 1 || $i === $current_page) {
                                     ?>
-                                        <li class="page-item"><a class="page-link" href="<? echo $new_url ?>">
+                                        <li class="page-item"><a class="page-link" href="<?php echo $new_url ?>">
                                                 <?php echo $i; ?>
                                             </a></li>
-                                    <?
+                                    <?php
                                     }
                                     if (($i === $next_2 && $next_2 < $my_courses_pagination['total_pages']) || $i === $pr_2 && $i > 1) {
                                     ?>
                                         <li style="margin-top: 6px">...</li>
-                                <?
+                                <?php
                                     }
 
                                 endfor; ?>
@@ -358,15 +358,15 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
 
                             </ul>
                         </div>
-                    <? } ?>
+                    <?php } ?>
                 </section>
-                <? if (!empty($completed_courses['results'])) { ?>
+                <?php if (!empty($completed_courses['results'])) { ?>
                     <section class="your-certificates">
                         <h4 class="your-certificates-title">
                             Your Certificates
                         </h4>
                         <div class="content">
-                            <?
+                            <?php
                             if (!empty($completed_courses['results'])) {
                                 foreach ($completed_courses['results'] as $key => $course) {
                                     $course_id = $course->post_id;
@@ -392,39 +392,39 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                                     // $certificate_link = learndash_get_course_certificate_link($course_id, get_current_user_id());
                             ?>
 
-                                    <div class="cert-pdf" id="<? echo $course_id ?>">
-                                        <? $cert_content = $this->replace_course_info($cert_post->post_content, $course_id) ?>
-                                        <? echo do_shortcode($cert_content) ?>
+                                    <div class="cert-pdf" id="<?php echo $course_id ?>">
+                                        <?php $cert_content = $this->replace_course_info($cert_post->post_content, $course_id) ?>
+                                        <?php echo do_shortcode($cert_content) ?>
                                     </div>
                                     <div>
                                         <div class="card">
                                             <div class="course-card-pattern">
-                                                <img src="<? echo $image ?>" alt="course-thumbnail">
+                                                <img src="<?php echo $image ?>" alt="course-thumbnail">
                                             </div>
                                             <div class="card-content">
-                                                <a href="<? echo $course_link ?>">
+                                                <a href="<?php echo $course_link ?>">
                                                     <div class="card-title">
                                                         <p>
-                                                            <? echo $title ?>
+                                                            <?php echo $title ?>
                                                         </p>
                                                     </div>
                                                 </a>
                                                 <p class="provider">
                                                     by
-                                                    <? echo $course_author ?>
+                                                    <?php echo $course_author ?>
                                                 </p>
                                                 <p class="lessons-count">
-                                                    <? echo $lessons_count ?> lessons
+                                                    <?php echo $lessons_count ?> lessons
                                                 </p>
                                                 <div class="completed-progress-bar">
                                                 </div>
                                                 <div class="card-footer">
                                                     <p>Certificate Achieved</p>
                                                     <div class="icons">
-                                                        <?
+                                                        <?php
                                                         $cert = learndash_get_course_certificate_link($course_id);
                                                         ?>
-                                                        <a href="<? echo $cert ?>" download>
+                                                        <a href="<?php echo $cert ?>" download>
                                                             <img src="/wp-content/plugins/academy-africa/includes/assets/images/download.svg" style="cursor: pointer;" alt="download" />
                                                         </a>
 
@@ -436,7 +436,7 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                                         </div>
                                     </div>
 
-                            <?
+                            <?php
                                 }
                             }
                             ?>
@@ -456,12 +456,12 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
 
                                 <!-- Page links -->
                                 <?php for ($i = 1; $i <= $certificate_pagination['total_pages']; $i++) : ?>
-                                    <?
+                                    <?php
                                     $current_url_params = $_GET;
                                     $current_url_params["courses_page"] = $i;
                                     $new_url = add_query_arg($current_url_params, home_url($_SERVER['REQUEST_URI']));
                                     ?>
-                                    <li class="page-item"><a class="page-link" href="<? echo $new_url ?>">
+                                    <li class="page-item"><a class="page-link" href="<?php echo $new_url ?>">
                                             <?php echo $i; ?>
                                         </a></li>
                                 <?php endfor; ?>
@@ -478,7 +478,7 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                             </ul>
                         </div>
                     </section>
-                <?
+                <?php
 
                 }
                 ?>
@@ -496,7 +496,7 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                         const height = doc.internal.pageSize.getHeight();
                         doc.html(pdfjs, {
                             callback: function(doc) {
-                                doc.save(`<? echo $user['first_name'] . ' ' . $user['first_name'] ?> | ${courseTitle}.pdf`);
+                                doc.save(`<?php echo $user['first_name'] . ' ' . $user['first_name'] ?> | ${courseTitle}.pdf`);
                             },
                             width: width,
                             height,
@@ -534,6 +534,6 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                 });
             </script>
         </main>
-<?
+<?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/partners.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/partners.php
@@ -140,22 +140,22 @@ class Academy_Africa_Partners extends \Elementor\Widget_Base
             <div class="partners">
                 <div class="title">
                     <h4 class="cfa-title">
-                        <? echo $title ?>
+                        <?php echo $title ?>
                     </h4>
                 </div>
                 <div class="partner-content">
-                    <?
+                    <?php
                     if (!empty($our_partners)) {
                         foreach ($our_partners as $partner) {
                             $icon = $partner["icon"];
                             $name = $partner["name"];
                             $url = $partner["url"];
                             ?>
-                            <a href="<? echo $url ?>" target="_blank" class="partner-link">
-                                <img src="<? echo $icon ?>" alt="<? echo $name ?>" class="partner" />
-                                <!-- <div class="partner" style="background: url(<? echo $icon ?>); background-size: cover; background-position: center; background-repeat: no-repeat; background-color: lightgray;"></div> -->
+                            <a href="<?php echo $url ?>" target="_blank" class="partner-link">
+                                <img src="<?php echo $icon ?>" alt="<?php echo $name ?>" class="partner" />
+                                <!-- <div class="partner" style="background: url(<?php echo $icon ?>); background-size: cover; background-position: center; background-repeat: no-repeat; background-color: lightgray;"></div> -->
                             </a>
-                            <?
+                            <?php
                         }
                     }
                     ?>
@@ -164,22 +164,22 @@ class Academy_Africa_Partners extends \Elementor\Widget_Base
             <hr />
             <div class="other-partners">
                 <h1 class="other-partners-title">
-                    <? echo $other_partners_title ?>
+                    <?php echo $other_partners_title ?>
                 </h1>
                 <div class="other-partners-content">
-                    <?
+                    <?php
                     if (!empty($other_partners)) {
                         foreach ($other_partners as $partner) {
                             $icon = $partner["icon"];
                             $name = $partner["name"];
                             $url = $partner["url"];
                             ?>
-                            <a href="<? echo $url ?>" target="_blank" class="partner-tag">
+                            <a href="<?php echo $url ?>" target="_blank" class="partner-tag">
                                 <div class="partner-tag-content">
-                                    <? echo $name ?>
+                                    <?php echo $name ?>
                                 </div>
                             </a>
-                            <?
+                            <?php
                         }
                     }
                     ?>
@@ -187,6 +187,6 @@ class Academy_Africa_Partners extends \Elementor\Widget_Base
             </div>
         </div>
 
-        <?
+        <?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/slider.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/slider.php
@@ -149,6 +149,6 @@ class Academy_Africa_Slider  extends \Elementor\Widget_Base
                 });
             });
         </script>
-<?
+<?php
     }
 }

--- a/wp-content/themes/academyAfrica/learndash/ld30/course.php
+++ b/wp-content/themes/academyAfrica/learndash/ld30/course.php
@@ -157,7 +157,7 @@ if (false === $orgs_data) {
         display: none;
     }
 </style>
-<?
+<?php
 $is_cert = isset($_GET["certificate"]);
 if ($course_status == "Completed" && $is_cert) {
     get_template_part('template-parts/course_completed', null, array('course_id' => $course_id));
@@ -438,6 +438,6 @@ if ($course_status == "Completed" && $is_cert) {
 
         </div>
     </div>
-<?
+<?php
 }
 ?>

--- a/wp-content/themes/academyAfrica/search.php
+++ b/wp-content/themes/academyAfrica/search.php
@@ -101,35 +101,35 @@ if ($no_of_pages > 1 && $current_page <= $no_of_pages) {
         'sort' => $sort
     ]); ?>
     <div class="search-page-main" id="all-courses">
-        <? if (!empty($s)) {
+        <?php if (!empty($s)) {
         ?>
             <div class="search-page-header">
 
                 <p class="search-page-subtitle">
-                    <? echo $the_query->found_posts ?> results for:
+                    <?php echo $the_query->found_posts ?> results for:
                 </p>
                 <h1 class="search-page-title">
-                    "<? echo $s ?>"
+                    "<?php echo $s ?>"
                 </h1>
 
             </div>
-        <?
+        <?php
         }
         ?>
         <div class="filters">
-            <? if (empty($allFilters)) { ?>
+            <?php if (empty($allFilters)) { ?>
                 <div class="filter-section">
                     <div class="sort">
                         <div class="label">
                             Sort By:
                         </div>
                         <select name="sort" id="courses-sort" class="select" onchange="sortCourses(this)">
-                            <?
+                            <?php
                             foreach ($sort_options as $key => $option) {
                                 $selected = $sort == $key ? "selected" : "";
                             ?>
-                                <option <? echo $selected ?> value="<? echo $key ?>"><? echo $option["name"] ?></option>
-                            <?
+                                <option <?php echo $selected ?> value="<?php echo $key ?>"><?php echo $option["name"] ?></option>
+                            <?php
                             }
                             ?>
                         </select>
@@ -150,18 +150,18 @@ if ($no_of_pages > 1 && $current_page <= $no_of_pages) {
                         </button>
                     </div>
                 </div>
-            <? } ?>
-            <? if (!empty($allFilters)) { ?>
+            <?php } ?>
+            <?php if (!empty($allFilters)) { ?>
                 <div class="selected-filters">
                     <div class="filters-list">
-                        <?
+                        <?php
                         foreach ($orgs as $org) {
                         ?>
                             <div class="filter">
                                 <div class="filter-name">
-                                    <? echo $org ?>
+                                    <?php echo $org ?>
                                 </div>
-                                <button class="filter-remove" onclick="removeFilter('organization', '<? echo $org ?>')">
+                                <button class="filter-remove" onclick="removeFilter('organization', '<?php echo $org ?>')">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="17" viewBox="0 0 16 17" fill="none">
                                         <path d="M8.0026 15.1693C11.6845 15.1693 14.6693 12.1845 14.6693 8.5026C14.6693 4.82071 11.6845 1.83594 8.0026 1.83594C4.32071 1.83594 1.33594 4.82071 1.33594 8.5026C1.33594 12.1845 4.32071 15.1693 8.0026 15.1693Z" stroke="#0C1A81" stroke-linecap="round" stroke-linejoin="round" />
                                         <path d="M10 6.5L6 10.5" stroke="#0C1A81" stroke-linecap="round" stroke-linejoin="round" />
@@ -169,7 +169,7 @@ if ($no_of_pages > 1 && $current_page <= $no_of_pages) {
                                     </svg>
                                 </button>
                             </div>
-                        <?
+                        <?php
                         }
                         ?>
                     </div>
@@ -191,14 +191,14 @@ if ($no_of_pages > 1 && $current_page <= $no_of_pages) {
                         </button>
                     </div>
                 </div>
-            <? } ?>
+            <?php } ?>
         </div>
         <div class="search-page-results">
             <?php
             if ($the_query->have_posts()) {
             ?>
                 <div class="list">
-                    <?
+                    <?php
 
                     foreach ($the_query->posts as $post) {
                         $course_title = get_the_title($post);
@@ -224,11 +224,11 @@ if ($no_of_pages > 1 && $current_page <= $no_of_pages) {
                                 'students' => $students
                             ]
                         ); ?>
-                    <?
+                    <?php
                     }
                     ?>
                 </div>
-            <?
+            <?php
             } else {
                 echo '<div class="no-results">';
                 echo '<button class="clear-filters" onclick="clearFilters()">Clear Filters</button>';
@@ -252,37 +252,37 @@ if ($no_of_pages > 1 && $current_page <= $no_of_pages) {
                     View All
                 </a>
                 <ul class="pagination">
-                    <?
+                    <?php
                     if ($current_page > 1) {
                     ?>
-                        <li class="page-item"><a class="page-link" href="<? echo get_pagenum_link($current_page - 1) ?>">
+                        <li class="page-item"><a class="page-link" href="<?php echo get_pagenum_link($current_page - 1) ?>">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
                                     <path d="M10 12L6 8L10 4" stroke="#616582" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
                                 </svg>
                             </a></li>
-                        <?
+                        <?php
                     }
                     for ($i = 1; $i <= $no_of_pages; $i++) {
                         if ($i == $current_page) {
                         ?>
                             <li class="page-item active">
-                                <a class="page-link" href="<? echo get_pagenum_link($i) ?>"><? echo $i ?></a>
+                                <a class="page-link" href="<?php echo get_pagenum_link($i) ?>"><?php echo $i ?></a>
                             </li>
-                        <?
+                        <?php
                         } else {
                         ?>
-                            <li class="page-item"><a class="page-link" href="<? echo get_pagenum_link($i) ?>"><? echo $i ?></a></li>
-                        <?
+                            <li class="page-item"><a class="page-link" href="<?php echo get_pagenum_link($i) ?>"><?php echo $i ?></a></li>
+                        <?php
                         }
                     }
                     if ($current_page < $no_of_pages) {
                         ?>
-                        <li class="page-item"><a class="page-link" href="<? echo get_pagenum_link($current_page + 1) ?>">
+                        <li class="page-item"><a class="page-link" href="<?php echo get_pagenum_link($current_page + 1) ?>">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
                                     <path d="M6 12L10 8L6 4" stroke="#616582" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
                                 </svg>
                             </a></li>
-                    <?
+                    <?php
                     }
                     ?>
                 </ul>

--- a/wp-content/themes/academyAfrica/single-ac-learning-path.php
+++ b/wp-content/themes/academyAfrica/single-ac-learning-path.php
@@ -35,11 +35,11 @@ $courses = get_field('courses', $learning_path_id) ?: [];
                     Take the courses
                 </div>
                 <div class="content">
-                    <? the_content() ?>
+                    <?php the_content() ?>
                 </div>
                 <div class="list">
                     <?php foreach ($courses as $course_index =>  $course) : ?>
-                        <?
+                        <?php
                         $course_thumbnail = get_the_post_thumbnail_url($course);
                         $course_title = $course->post_title;
                         $course_excerpt = $course->post_excerpt;
@@ -52,7 +52,7 @@ $courses = get_field('courses', $learning_path_id) ?: [];
                         ?>
                         <div class="individual-course">
                             <div class="course-index">
-                                <? echo $course_index + 1 ?>
+                                <?php echo $course_index + 1 ?>
                             </div>
                             <div class="course">
                                 <?php get_template_part(
@@ -68,11 +68,11 @@ $courses = get_field('courses', $learning_path_id) ?: [];
                                     ]
                                 ); ?>
                                 <div class="extra-course-details">
-                                    <a href="<? echo $course_link ?>" class="course-title">
-                                        <? echo $course_title ?>
+                                    <a href="<?php echo $course_link ?>" class="course-title">
+                                        <?php echo $course_title ?>
                                     </a>
                                     <div class="course-excerpt">
-                                        <? echo $course_excerpt ?>
+                                        <?php echo $course_excerpt ?>
                                     </div>
                                 </div>
                             </div>
@@ -85,7 +85,7 @@ $courses = get_field('courses', $learning_path_id) ?: [];
         </div>
     </div>
     <div id="learning">
-        <? get_template_part('template-parts/ac_learning_print', 'template', [
+        <?php get_template_part('template-parts/ac_learning_print', 'template', [
             'learning_path_title' => $learning_path_title,
             'learning_path_excerpt' => $learning_path_excerpt,
             'courses' => $courses,

--- a/wp-content/themes/academyAfrica/single-event.php
+++ b/wp-content/themes/academyAfrica/single-event.php
@@ -39,34 +39,34 @@ require_once __DIR__ . '/includes/utils/countries.php';
             $countries = get_field("countries", $post_id) ?: [];
     ?>
             <h1 class="cfa-title">
-                <? echo $post_title ?>
+                <?php echo $post_title ?>
             </h1>
             <div class="image-container">
-                <img width="100%" class="featured-image" src="<? echo $featured_image_url ?>"
-                    alt="<? echo $post_id ?>">
+                <img width="100%" class="featured-image" src="<?php echo $featured_image_url ?>"
+                    alt="<?php echo $post_id ?>">
             </div>
             <div class="details">
                 <div class="custom-data">
                     <p class="speaker">
-                        <? echo isset($speaker) ? $speaker->display_name : "" ?>
+                        <?php echo isset($speaker) ? $speaker->display_name : "" ?>
                     </p>
                     <div class="with-icons">
                         <img src="/wp-content/themes/academyAfrica/assets/images/icons/Type=calendar, Size=16, Color=Black.svg" alt="">
                         <p style="margin: 0" class="date">
-                            <? echo $date ?>
+                            <?php echo $date ?>
                         </p>
                     </div>
 
                     <div class="with-icons">
                         <img src="/wp-content/themes/academyAfrica/assets/images/icons/Type=world, Size=16, Color=Black.svg" alt="">
                         <p style="margin: 0" class="language">
-                            <? echo $language ?>
+                            <?php echo $language ?>
                         </p>
                     </div>
                     <div class="with-icons">
                         <img src="/wp-content/themes/academyAfrica/assets/images/icons/Type=location, Size=16, Color=Black.svg" alt="">
                         <p style="margin: 0" class="time">
-                            <?
+                            <?php
                             if (isset($countries)) {
                                 foreach ($countries as $country) {
                                     echo country_flag_emoji($country['value']);
@@ -81,77 +81,77 @@ require_once __DIR__ . '/includes/utils/countries.php';
                     <div style="margin-bottom: 20px">
                         <?php get_template_part('template-parts/social_share', 'template'); ?>
                     </div>
-                    <?
+                    <?php
                     if ($is_past_event) {
                     ?>
-                        <a href="<? echo $resources ?>" <? echo $resources ? 'download' : '' ?>>
+                        <a href="<?php echo $resources ?>" <?php echo $resources ? 'download' : '' ?>>
                             <button class="button resources">
                                 <img src="/wp-content/themes/academyAfrica/assets/images/MOOCButton.svg" alt="">
-                                <? echo $resources_text ?>
+                                <?php echo $resources_text ?>
                             </button>
                         </a>
-                    <?
+                    <?php
                     } else {
                     ?>
-                        <a href="<? echo $registration_link ?>">
+                        <a href="<?php echo $registration_link ?>">
                             <button class="button cta signup-button">
-                                <? echo $register_text ?>
+                                <?php echo $register_text ?>
                             </button>
                         </a>
 
-                    <?
+                    <?php
                     }
                     ?>
                 </div>
             </div>
             <hr class="divider">
             <p class="content">
-                <? echo $post_content ?>
+                <?php echo $post_content ?>
             </p>
             <div class="linked-post">
-                <h4 class="title"><? echo $speaker_title ?></h4>
+                <h4 class="title"><?php echo $speaker_title ?></h4>
 
-                <?
+                <?php
                 if (isset($speakers) && is_array($speakers) && count($speakers) > 0) {
                     foreach ($speakers as $speaker) {
                         $sp_title = $speaker->post_title;
                         $avatar_url = get_the_post_thumbnail_url($speaker->ID, 'full');
                         $sp_desc = get_the_excerpt($speaker->ID);
                 ?>
-                        <img style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; margin: 0;" src="<? echo $avatar_url ?>" alt="<? echo $speaker->display_name ?>" class="logo">
+                        <img style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; margin: 0;" src="<?php echo $avatar_url ?>" alt="<?php echo $speaker->display_name ?>" class="logo">
                         <p style="text-transform: capitalize; margin: 0" class="name">
-                            <? echo $sp_title ?>
+                            <?php echo $sp_title ?>
                         </p>
                         <p class="description" style="margin-bottom: 32px; margin-top: 16px;">
-                            <? echo $sp_desc ?>
+                            <?php echo $sp_desc ?>
                         </p>
-                <?
+                <?php
                     }
                 }
                 ?>
             </div>
             <div class="linked-post">
-                <?
+                <?php
                 if (isset($organisations) && is_array($organisations) && count($organisations) > 0):
                 foreach ($organisations as $organisation) {
                     $org_title = $organisation->post_title;
                     $img = get_the_post_thumbnail_url($organisation->ID, 'full');
                     $desc = get_the_excerpt($organisation->ID);
                 ?>
-                    <h4 class="title"><? echo $or_title ?></h4>
-                    <img src="<? echo $img ?>" alt="<? echo $org_title ?>" style="height: 100px;" class="logo">
+                    <h4 class="title"><?php echo $or_title ?></h4>
+                    <img src="<?php echo $img ?>" alt="<?php echo $org_title ?>" style="height: 100px;" class="logo">
                     <p class="name">
-                        <? echo $org_title ?>
+                        <?php echo $org_title ?>
                     </p>
                     <p class="description">
-                        <? echo $desc ?>
+                        <?php echo $desc ?>
                     </p>
-                <?
+                <?php
                 }
                 endif;
                 ?>
             </div>
-    <?
+    <?php
         endwhile;
     endif;
     ?>
@@ -161,7 +161,7 @@ require_once __DIR__ . '/includes/utils/countries.php';
                 <path d="M10 4L6 8L10 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                     stroke-linejoin="round" />
             </svg>
-            <? echo $back_text ?>
+            <?php echo $back_text ?>
         </a>
     </div>
 </main>

--- a/wp-content/themes/academyAfrica/single-resource.php
+++ b/wp-content/themes/academyAfrica/single-resource.php
@@ -61,6 +61,6 @@ $course_intro    = $post_data->post_content;
         </div>
     </div>
 </div>
-<?
+<?php
 get_footer();
 ?>

--- a/wp-content/themes/academyAfrica/template-parts/404.php
+++ b/wp-content/themes/academyAfrica/template-parts/404.php
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) {
 ?>
 
 <?php get_header(); ?>
-<?
+<?php
 $status_code = 404;
 $title = academyafrica_translate('PAGE NOT FOUND');
 $description = academyafrica_translate('There seems to be an error on this page. Please contact us for more details');
@@ -27,20 +27,20 @@ $home = academyafrica_translate('Home');
         <div></div>
         <div class="content">
             <p class="code">
-                <? echo $status_code ?>
+                <?php echo $status_code ?>
             </p>
             <p class="text">
-                <? echo $title ?>
+                <?php echo $title ?>
             </p>
             <p class="description">
-                <? echo $description ?>
+                <?php echo $description ?>
             </p>
             <div class="actions">
                 <a class="button" href="" onclick="location.reload();" data-analytics-action="refresh">
-                    <? echo $refresh ?>
+                    <?php echo $refresh ?>
                 </a>
                 <a class="button" href="/" data-analytics-action="home">
-                    <? echo $home ?>
+                    <?php echo $home ?>
                 </a>
             </div>
         </div>

--- a/wp-content/themes/academyAfrica/template-parts/ac_learning_print.php
+++ b/wp-content/themes/academyAfrica/template-parts/ac_learning_print.php
@@ -6,7 +6,7 @@ $content = $args['content'];
 
 ?>
 
-<link rel="stylesheet" href="<? echo get_stylesheet_directory_uri() ?>/assets/css/dist/print/ac_learning_print.css">
+<link rel="stylesheet" href="<?php echo get_stylesheet_directory_uri() ?>/assets/css/dist/print/ac_learning_print.css">
 <div class="pdf-template">
     <div class="template">
         <div class="template__title">
@@ -15,10 +15,10 @@ $content = $args['content'];
             </div>
             <div class="template__title__text">
                 <div class="cfa-title">
-                    <? echo $learning_path_title ?>
+                    <?php echo $learning_path_title ?>
                 </div>
                 <div class="cfa-excerpt">
-                    <? echo $learning_path_excerpt ?>
+                    <?php echo $learning_path_excerpt ?>
                 </div>
             </div>
         </div>
@@ -28,13 +28,13 @@ $content = $args['content'];
                     <?php echo esc_html(academyafrica_translate('Take the courses')); ?>
                 </div>
                 <div class="content">
-                    <? echo $content ?>
+                    <?php echo $content ?>
                 </div>
                 <div class="list">
                     <?php
                     $counter = 0;
                     foreach ($courses as $course_index =>  $course) : ?>
-                        <?
+                        <?php
                         $course_thumbnail = get_the_post_thumbnail_url($course);
                         $course_title = $course->post_title;
                         $course_excerpt = $course->post_excerpt;
@@ -52,7 +52,7 @@ $content = $args['content'];
                         ?>
                         <div class="individual-course">
                             <div class="course-index">
-                                <? echo $course_index + 1 ?>
+                                <?php echo $course_index + 1 ?>
                             </div>
                             <div class="course">
                                 <?php get_template_part(
@@ -68,11 +68,11 @@ $content = $args['content'];
                                     ]
                                 ); ?>
                                 <div class="extra-course-details">
-                                    <a href="<? echo $course_link ?>" class="course-title">
-                                        <? echo $course_title ?>
+                                    <a href="<?php echo $course_link ?>" class="course-title">
+                                        <?php echo $course_title ?>
                                     </a>
                                     <div class="course-excerpt">
-                                        <? echo $course_excerpt ?>
+                                        <?php echo $course_excerpt ?>
                                     </div>
                                 </div>
                             </div>

--- a/wp-content/themes/academyAfrica/template-parts/change-password.php
+++ b/wp-content/themes/academyAfrica/template-parts/change-password.php
@@ -1,5 +1,5 @@
 
-<?
+<?php
 $is_success = false;
 if(isset($_POST["rp_key"])){
         $key = $_POST["rp_key"];
@@ -23,7 +23,7 @@ if(isset($_POST["rp_key"])){
 ?>
 <div style="min-height: calc(100vh - 620px);" class="login">
 <div class="content" id="login-modal-content">
-        <?
+        <?php
         $url = home_url('/login?action=rp&key='.$_GET["key"]).'&login='.$_GET["login"];
         if(!$is_success) {
         ?>
@@ -33,13 +33,13 @@ if(isset($_POST["rp_key"])){
         <p class="subtitle">
             <?php echo esc_html(academyafrica_translate('Enter your new password below or generate one')); ?>
         </p>
-        <form name="resetpassform" id="resetpassform" action="<? echo $url ?>" method="post" autocomplete="off">
-			<input type="hidden" id="user_login" name="user_login" value="<? echo $_GET["login"]?>" autocomplete="off">
+        <form name="resetpassform" id="resetpassform" action="<?php echo $url ?>" method="post" autocomplete="off">
+			<input type="hidden" id="user_login" name="user_login" value="<?php echo $_GET["login"]?>" autocomplete="off">
             <label for="password"><?php echo esc_html(academyafrica_translate('Password')); ?></label>
             <input placeholder="<?php echo esc_attr(academyafrica_translate('Password')); ?>" name="pass1" type="password">
             <label for="pass2"><?php echo esc_html(academyafrica_translate('Confirm Password')); ?></label>
             <input placeholder="<?php echo esc_attr(academyafrica_translate('Password')); ?>" name="pass2" type="password">
-            <input type="text" hidden name="rp_key" value="<? echo $_GET["key"]?>">
+            <input type="text" hidden name="rp_key" value="<?php echo $_GET["key"]?>">
             <button class="button primary" style="width: 100%; margin: 24px 0;" type="submit"><?php echo esc_html(academyafrica_translate('SAVE PASSWORD')); ?></button>
 		</form>
         <footer style="display: flex; justify-content: flex-end;" class="modal-footers">
@@ -47,14 +47,14 @@ if(isset($_POST["rp_key"])){
             <!-- <button class="button primary" type="submit">Login</button> -->
             <a style="font-size: 14px; color: var(--Black, #000);" href="javascript:history.back()"><?php echo esc_html(academyafrica_translate('Back')); ?></a>
         </footer>
-        <?
+        <?php
         }else {
             ?>
             <p><?php echo esc_html(academyafrica_translate('Your password has been successfully reset. You can now')); ?> <a style="color: #0C1A81; text-decoration: none;" href="/login/?redirect_url=/learning-pathways">
         <strong><?php echo esc_html(academyafrica_translate('log in')); ?></strong>
         </a> <?php echo esc_html(academyafrica_translate('with your new password.')); ?></p>
-            <?
+            <?php
         }?>
     </div>
 </div>
-<?
+<?php

--- a/wp-content/themes/academyAfrica/template-parts/course_card.php
+++ b/wp-content/themes/academyAfrica/template-parts/course_card.php
@@ -10,30 +10,30 @@ $course_link = $args['course_link'];
 $course_index = isset($args['course_index']) ? $args['course_index'] : uniqid();
 ?>
 
-<a href="<? echo $course_link ?>" class="course-card" id="course-card-<? echo $course_index ?>">
+<a href="<?php echo $course_link ?>" class="course-card" id="course-card-<?php echo $course_index ?>">
     <div class="card">
         <div class="course-card-pattern">
-            <img src="<? echo $logo_url
+            <img src="<?php echo $logo_url
                         ?>"
                 alt="course-thumbnail">
         </div>
         <div class="course-card-content">
             <p class="course-title">
-                <? echo $course_title ?>
+                <?php echo $course_title ?>
             </p>
             <div class="course-meta">
                 <p class="course-author">
-                    <?php echo esc_html(academyafrica_translate('By')); ?> <? echo $course_author ?>
+                    <?php echo esc_html(academyafrica_translate('By')); ?> <?php echo $course_author ?>
                 </p>
                 <div class="course-details">
                     <div class="course-students">
                         <div class="icon">
-                            <img src="<? echo get_stylesheet_directory_uri() ?>/assets/images/user.svg" alt="students">
+                            <img src="<?php echo get_stylesheet_directory_uri() ?>/assets/images/user.svg" alt="students">
                         </div>
-                        <p class="value"><? echo $students ?></p>
+                        <p class="value"><?php echo $students ?></p>
                     </div>
                     <p class="course-price">
-                        <? echo $course_price ?>
+                        <?php echo $course_price ?>
                     </p>
                 </div>
             </div>
@@ -41,17 +41,17 @@ $course_index = isset($args['course_index']) ? $args['course_index'] : uniqid();
     </div>
 </a>
 <script>
-    document.getElementById('course-card-<? echo $course_index ?>').addEventListener('click', function() {
+    document.getElementById('course-card-<?php echo $course_index ?>').addEventListener('click', function() {
         window.dataLayer = window.dataLayer || [];
         dataLayer.push({
             'event': 'course_card_click',
-            'course_title': '<? echo $course_title ?>',
-            'course_link': '<? echo $course_link ?>',
+            'course_title': '<?php echo $course_title ?>',
+            'course_link': '<?php echo $course_link ?>',
         });
         gtag('event', 'course_card_click', {
             'event_category': 'engagement',
-            'event_label': '<? echo $course_title ?>',
-            'course_link': '<? echo $course_link ?>'
+            'event_label': '<?php echo $course_title ?>',
+            'course_link': '<?php echo $course_link ?>'
         });
     });
 </script>

--- a/wp-content/themes/academyAfrica/template-parts/course_completed.php
+++ b/wp-content/themes/academyAfrica/template-parts/course_completed.php
@@ -69,23 +69,23 @@ global $shortcode_tags;
 ?>
 <div class="course-completed">
     <h4 class="cfa-title">
-        <? echo $congratulations ?>
+        <?php echo $congratulations ?>
     </h4>
     <div class="cert-pdf">
-        <? echo do_shortcode($cert_post->post_content) ?>
+        <?php echo do_shortcode($cert_post->post_content) ?>
     </div>
     <div class="content">
         <?php get_template_part('template-parts/certificate', 'template', array("academy_head" => $academy_head, "course" => array("date" => $completion_date, "name" => $certificate_course), "user" => $user)); ?>
         <div style="flex: 1; display: flex; justify-content: center;">
             <div class="share-section">
                 <h4 class="title">
-                    <? echo $share_title ?>
+                    <?php echo $share_title ?>
                 </h4>
                 <div class="share" style="display: flex; justify-content: center;">
                     <?php get_template_part('template-parts/social_share', 'template', array('message' => $share_message)); ?>
                 </div>
                 <div style="display: flex; gap: 16px; justify-content: center; margin-top: 16px; flex-direction: column;">
-                    <a href="<? echo learndash_get_course_certificate_link($course_id) ?>" download>
+                    <a href="<?php echo learndash_get_course_certificate_link($course_id) ?>" download>
                         <button class="button primary" id="download-certificate">
                             <svg width="17" height="17" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg">
                                 <g id="Icon">
@@ -97,7 +97,7 @@ global $shortcode_tags;
                             <?php echo esc_html(academyafrica_translate('Download')); ?>
                         </button>
                     </a>
-                    <a href="<? echo get_permalink($course_id) ?>">
+                    <a href="<?php echo get_permalink($course_id) ?>">
                         <button class="button primary">
                             <?php echo esc_html(academyafrica_translate('View Course')); ?>
                         </button>
@@ -119,7 +119,7 @@ global $shortcode_tags;
             const height = doc.internal.pageSize.getHeight();
             doc.html(pdfjs, {
                 callback: function(doc) {
-                    doc.save(`<? echo $user['first_name'] . ' ' . $user['first_name'] ?> | <? echo $certificate_course ?>.pdf`);
+                    doc.save(`<?php echo $user['first_name'] . ' ' . $user['first_name'] ?> | <?php echo $certificate_course ?>.pdf`);
                 },
                 width: width,
                 height,

--- a/wp-content/themes/academyAfrica/template-parts/filter_bar.php
+++ b/wp-content/themes/academyAfrica/template-parts/filter_bar.php
@@ -11,27 +11,27 @@ $sort_options = $args["sort_options"] ?? [];
     <div class="sidebar" id="sidebar">
         <div class="sort">
             <p class="sort-by">
-                <? echo $sort_by ?>
+                <?php echo $sort_by ?>
             </p>
             <select name="sort" id="courses-sort" class="select" onchange="sortCourses(this)">
-                <?
+                <?php
                 foreach ($sort_options as $key => $option) {
                     $selected = $sort == $key ? "selected" : "";
                 ?>
-                    <option <? echo $selected ?> value="<? echo $key ?>"><? echo $option["name"] ?></option>
-                <?
+                    <option <?php echo $selected ?> value="<?php echo $key ?>"><?php echo $option["name"] ?></option>
+                <?php
                 }
                 ?>
             </select>
         </div>
-        <? if (!empty($filter_options)) {
+        <?php if (!empty($filter_options)) {
         ?>
             <div class="filter" id="side-filter-bar">
                 <p class="filter-by">
-                    <? echo $filter_by ?>
+                    <?php echo $filter_by ?>
                 </p>
                 <div class="filter-body">
-                    <?
+                    <?php
                     if (!empty($filter_options)) {
                         foreach ($filter_options as $item) {
                             $title = $item["title"];
@@ -39,62 +39,62 @@ $sort_options = $args["sort_options"] ?? [];
                     ?>
                             <div class="filter-item">
                                 <p class="filter-by-title">
-                                    <? echo $title ?>
+                                    <?php echo $title ?>
                                 </p>
-                                <?
+                                <?php
                                 if (!empty($options)) {
                                 ?>
                                     <ul class="filter-list">
-                                        <?
+                                        <?php
                                         foreach ($options as $options_index => $option) {
                                         ?>
-                                            <? if ($options_index >= 3) {
+                                            <?php if ($options_index >= 3) {
                                             ?>
                                                 <li class="hidden">
                                                     <label class="mui-checkbox">
-                                                        <input type="checkbox" onclick="filterSearchCourses(this, '<? echo $item["name"] ?>', '<? echo $option->name ?>')" value="<? echo $option->id ?>" name="<? echo $item["name"] . '-' . $option->name ?>">
+                                                        <input type="checkbox" onclick="filterSearchCourses(this, '<?php echo $item["name"] ?>', '<?php echo $option->name ?>')" value="<?php echo $option->id ?>" name="<?php echo $item["name"] . '-' . $option->name ?>">
                                                         <span class="checkmark"></span>
-                                                        <? echo $option->name ?>
+                                                        <?php echo $option->name ?>
                                                     </label>
                                                 </li>
-                                            <?
+                                            <?php
                                             } else {
                                             ?>
                                                 <li>
                                                     <label class="mui-checkbox">
-                                                        <input type="checkbox" onclick="filterSearchCourses(this, '<? echo $item["name"] ?>', '<? echo $option->name ?>')" value="<? echo $option->id ?>" name="<? echo $item["name"] . '-' . $option->name ?>">
+                                                        <input type="checkbox" onclick="filterSearchCourses(this, '<?php echo $item["name"] ?>', '<?php echo $option->name ?>')" value="<?php echo $option->id ?>" name="<?php echo $item["name"] . '-' . $option->name ?>">
                                                         <span class="checkmark"></span>
-                                                        <? echo $option->name ?>
+                                                        <?php echo $option->name ?>
                                                     </label>
                                                 </li>
-                                            <?
+                                            <?php
                                             }
                                             ?>
-                                        <?
+                                        <?php
                                         }
                                         ?>
                                     </ul>
-                                    <? if (count($options) > 3) {
+                                    <?php if (count($options) > 3) {
                                     ?>
                                         <div class="show-more">
                                             <button class="show-more-btn">
                                                 <?php echo esc_html(academyafrica_translate('Show More')); ?>
                                             </button>
                                         </div>
-                                    <?
+                                    <?php
                                     } ?>
-                                <?
+                                <?php
                                 }
                                 ?>
                             </div>
-                    <?
+                    <?php
                         }
                     }
                     ?>
                 </div>
             </div>
 
-        <?
+        <?php
         } ?>
     </div>
 </aside>
@@ -106,7 +106,7 @@ $sort_options = $args["sort_options"] ?? [];
             <div id="mobile-filters" class="mobile-filter">
                 <div class="filter-header">
                     <h4 class="filter-title">
-                        <? echo $filter_by ?>
+                        <?php echo $filter_by ?>
                     </h4>
                     <div class="close">
                         <button class="buttons" id="close-filter-modal">
@@ -127,7 +127,7 @@ $sort_options = $args["sort_options"] ?? [];
                     </div>
                 </div>
                 <div class="filters">
-                    <?
+                    <?php
                     if (!empty($filter_options)) {
                         foreach ($filter_options as $item) {
                             $title = $item["title"];
@@ -135,29 +135,29 @@ $sort_options = $args["sort_options"] ?? [];
 
                     ?>
                             <div class="accordion-parent">
-                                <button class="accordion"><? echo $title ?></button>
-                                <?
+                                <button class="accordion"><?php echo $title ?></button>
+                                <?php
                                 if (!empty($options)) {
                                 ?>
                                     <div class="panel">
                                         <ul>
-                                            <?
+                                            <?php
                                             foreach ($options as $option) {
                                             ?>
                                                 <li>
                                                     <label class="mui-checkbox">
-                                                        <input type="checkbox" onclick="filterSearchCourses(this, '<? echo $item["name"] ?>', '<? echo $option->name ?>')" value="<? echo $option->id ?>" name="<? echo $item["name"] . '-' . $option->name ?>">
+                                                        <input type="checkbox" onclick="filterSearchCourses(this, '<?php echo $item["name"] ?>', '<?php echo $option->name ?>')" value="<?php echo $option->id ?>" name="<?php echo $item["name"] . '-' . $option->name ?>">
                                                         <span class="checkmark"></span>
-                                                        <? echo $option->name ?>
+                                                        <?php echo $option->name ?>
                                                     </label>
                                                 </li>
-                                            <?
+                                            <?php
                                             }
                                             ?>
                                         </ul>
                                     </div>
                             </div>
-                <?
+                <?php
                                 }
                             }
                         }

--- a/wp-content/themes/academyAfrica/template-parts/footer.php
+++ b/wp-content/themes/academyAfrica/template-parts/footer.php
@@ -97,14 +97,14 @@ $newsletter_title = get_post_meta($footer->ID, 'newsletter_title', true);
                 <img height="110" width="250"
                     src="<?php echo $thumbnail_url ?>" alt=<?php echo get_bloginfo('name'); ?> class="logo">
                 <p class="description">
-                    <? echo $site_description ?>
+                    <?php echo $site_description ?>
                 </p>
                 <div class="footer-connect">
                     <span style="white-space: nowrap;">
-                        <? echo $stay_in_touch ?>
+                        <?php echo $stay_in_touch ?>
                     </span>
                     <div class="social-icons">
-                        <?
+                        <?php
                         if (!empty($social_media_links)) {
                             foreach ($social_media_links as $item) {
                                 $link = esc_url($item['link']['url']);
@@ -122,7 +122,7 @@ $newsletter_title = get_post_meta($footer->ID, 'newsletter_title', true);
         </div>
         <div class="item">
             <div class="links">
-                <?
+                <?php
                 if (!empty($menu_items)) {
                     foreach ($menu_items as $item) {
                         $page_link = esc_url($item['url']);
@@ -143,10 +143,10 @@ $newsletter_title = get_post_meta($footer->ID, 'newsletter_title', true);
         <div class="item">
             <div class="embed">
                 <p class="title">
-                    <? echo $newsletter_title ?>
+                    <?php echo $newsletter_title ?>
                 </p>
                 <div>
-                    <? echo $newsletter ?>
+                    <?php echo $newsletter ?>
                 </div>
             </div>
         </div>

--- a/wp-content/themes/academyAfrica/template-parts/login.php
+++ b/wp-content/themes/academyAfrica/template-parts/login.php
@@ -1,4 +1,4 @@
-<?
+<?php
 $error_message = get_transient('login_error_message');
 $activation_email_sent = get_transient('login_message_activation_email_sent');
 if ($error_message) {
@@ -61,7 +61,7 @@ if (isset($_GET['email_sent'])) {
 ?>
 
     <div class="login">
-        <?
+        <?php
         if (isset($_GET['verification']) && $_GET['verification'] === 'required') {
         ?>
             <div class="verification-resend">
@@ -153,7 +153,7 @@ if (isset($_GET['email_sent'])) {
                     <a style="font-size: 14px; color: var(--primary-700, #0c1a81);" href="javascript:history.back()"><?php echo esc_html(academyafrica_translate('Back')); ?></a>
                 </footer>
             </div>
-        <?
+        <?php
         }
         ?>
         <script>
@@ -206,4 +206,4 @@ if (isset($_GET['email_sent'])) {
 
         </script>
     </div>
-<?  }
+<?php  }

--- a/wp-content/themes/academyAfrica/template-parts/password-reset.php
+++ b/wp-content/themes/academyAfrica/template-parts/password-reset.php
@@ -28,8 +28,8 @@ function get_full_url($path = '', $search = '')
             </p>
             <div style="display:flex; gap: 8px">
                 <span class="description"><?php echo esc_html(academyafrica_translate('You can')); ?> </span>
-                <form action="<? echo wp_lostpassword_url() ?>" method="post">
-                    <input type="email" placeholder="<?php echo esc_attr(academyafrica_translate('Email')); ?>" id="user_login" name="user_login" value="<? echo $_GET['user_login'] ?>" required hidden>
+                <form action="<?php echo wp_lostpassword_url() ?>" method="post">
+                    <input type="email" placeholder="<?php echo esc_attr(academyafrica_translate('Email')); ?>" id="user_login" name="user_login" value="<?php echo $_GET['user_login'] ?>" required hidden>
                     <input type="text" hidden name="pass_reset" value="pass-reset">
                     <button class="description" style="background: none; border: none; padding: 0; margin: 0; font: inherit; color: #0C1A81; text-decoration: none; cursor: pointer; display: inline;"
                         onmouseover="this.style.textDecoration='underline';"
@@ -41,7 +41,7 @@ function get_full_url($path = '', $search = '')
             <span class="description"><?php echo esc_html(academyafrica_translate('or contact our support team for further assistance.')); ?></span>
 
         </div>
-    <?
+    <?php
     } else {
     ?>
         <div class="content" id="login-modal-content">
@@ -55,11 +55,11 @@ function get_full_url($path = '', $search = '')
                 <p id="login_error">
                 </p>
             </div>
-            <form action="<? echo wp_lostpassword_url() ?>" method="post">
+            <form action="<?php echo wp_lostpassword_url() ?>" method="post">
                 <label for="email"><?php echo esc_html(academyafrica_translate('Email')); ?></label>
                 <input type="email" placeholder="<?php echo esc_attr(academyafrica_translate('Email')); ?>" id="user_login" name="user_login" required>
                 <input type="text" hidden name="pass_reset" value="pass-reset">
-                <? echo do_shortcode('[bws_google_captcha]') ?>
+                <?php echo do_shortcode('[bws_google_captcha]') ?>
                 <button class="button primary" style="width: 100%; margin: 24px 0;" type="submit" id="reset-btn"><?php echo esc_html(academyafrica_translate('SUBMIT')); ?></button>
             </form>
             <footer style="display: flex; justify-content: flex-end;" class="modal-footers">
@@ -68,7 +68,7 @@ function get_full_url($path = '', $search = '')
                 <a style="font-size: 14px; color: var(--Black, #000);" href="javascript:history.back()"><?php echo esc_html(academyafrica_translate('Back')); ?></a>
             </footer>
         </div>
-    <?
+    <?php
     }
     ?>
     <script>

--- a/wp-content/themes/academyAfrica/template-parts/register.php
+++ b/wp-content/themes/academyAfrica/template-parts/register.php
@@ -1,4 +1,4 @@
-<?
+<?php
 function get_url_param($param_name)
 {
     // Check if the parameter exists in the URL
@@ -22,7 +22,7 @@ if ($success) {
             <p class="text">
             </p>
             <p style="max-width: 400px; margin: 0;" class="description">
-                <? echo $success ?>
+                <?php echo $success ?>
             </p>
             <div class="actions">
                 <a class="button" href="/login">
@@ -34,7 +34,7 @@ if ($success) {
             </div>
         </div>
     </div>
-<?
+<?php
 } else {
 ?>
     <div class="login" id="register-modal">
@@ -61,19 +61,19 @@ if ($success) {
                 <div></div><span><?php echo esc_html(academyafrica_translate('or')); ?></span>
                 <div></div>
             </div>
-            <?
+            <?php
             $error = get_url_param("error_message");
             if ($error) {
-            ?><div class="error_message"><?
+            ?><div class="error_message"><?php
                                             echo $error;
-                                            ?></div><?
+                                            ?></div><?php
                                                 }
                                                     ?>
-            <?
+            <?php
             $success_message = academyafrica_translate('You have successfully created your account! To begin using this site you will need to activate your account via the email we have just sent to your address.  Please check your email inbox or spam folder for an activation link.');
             $url = home_url('/login?action=register&success=' . urlencode($success_message));
             ?>
-            <form action="<? echo $url ?>" method="post" onsubmit="return validateForm()">
+            <form action="<?php echo $url ?>" method="post" onsubmit="return validateForm()">
                 <label for="firstName"><?php echo esc_html(academyafrica_translate('First Name')); ?></label>
                 <input placeholder="<?php echo esc_attr(academyafrica_translate('First Name')); ?>" name="firstName" type="text">
                 <label for="lastName"><?php echo esc_html(academyafrica_translate('Last Name')); ?></label>
@@ -92,7 +92,7 @@ if ($success) {
                 </div>
                 <div id="error-alert" style="color: red;"></div>
                 <input type="hidden" name="action" value="register">
-                <? echo do_shortcode('[bws_google_captcha]') ?>
+                <?php echo do_shortcode('[bws_google_captcha]') ?>
                 <button class="button primary" style="width: 100%; margin: 24px 0;" type="submit" id="register"><?php echo esc_html(academyafrica_translate('SIGN UP')); ?></button>
                 <label class="mui-checkbox">
                     <input type="checkbox">
@@ -145,6 +145,6 @@ if ($success) {
             </script>
         </div>
     </div>
-<?
+<?php
 }
 ?>

--- a/wp-content/themes/academyAfrica/template-parts/social_share.php
+++ b/wp-content/themes/academyAfrica/template-parts/social_share.php
@@ -5,7 +5,7 @@ $share_message = isset($args["message"]) ? $args["message"] : sprintf(academyafr
 ?>
 <div style="display: flex;" class="share-menu">
     <div style="color: #000; cursor: pointer; margin-right: 16px;" class="share-icon" onclick="toggleShareButtons()">
-        <img class='icon-image' src="<? echo get_stylesheet_directory_uri() ?>/assets/images/icons/Type=share, Size=24, Color=Black.svg" alt="<?php echo esc_attr(academyafrica_translate('Share')); ?>">
+        <img class='icon-image' src="<?php echo get_stylesheet_directory_uri() ?>/assets/images/icons/Type=share, Size=24, Color=Black.svg" alt="<?php echo esc_attr(academyafrica_translate('Share')); ?>">
     </div>
     <div class="share-icons">
         <!-- LinkedIn -->


### PR DESCRIPTION
## Summary

Addresses **#45** (P0 in the #58 audit tracker): the theme relied on `short_open_tag=On` across 45 PHP files, so a PHP/host config change would break theme bootstrap and templates.

Replaces every configuration-dependent `<?` short open tag with `<?php` across **45 custom PHP files** in the `academyAfrica` theme and `academy-africa` plugin. The `academy-error-logger.php` mu-plugin had none.

This is a **purely mechanical** change, kept separate from behavioral fixes:
- `<?` + whitespace → `<?php`
- `<?php`, `<?=`, and `<?xml` are left untouched (there were no `<?=` short-echo tags in the codebase).
- Diff is perfectly symmetric: 538 insertions / 538 deletions.

## Verification

- `php -l -d short_open_tag=Off` passes on **all 75 custom PHP files (75/75)**.
- Before this change, originals such as `functions.php` and `search.php` produced parse errors (unclosed brace) under `short_open_tag=Off`; `footer.php`'s `<? echo ?>` tags would have rendered as literal text.

## Still needed before closing #45

Smoke tests with `short_open_tag=Off` on staging (login, Elementor widgets, search, LearnDash, events, certificates, profiles) — these require the live WP environment and are not runnable in-repo.

Refs #58