### PR TITLE
fix(auth): consolidate account verification and activation state (#56)

### DIFF
--- a/wp-content/themes/academyAfrica/functions.php
+++ b/wp-content/themes/academyAfrica/functions.php
@@ -268,56 +268,200 @@ function is_activation_key_valid($user_id, $key)
         return false;
     }
 
-    return $stored_key === $key;
+    // Constant-time comparison to avoid leaking the key via timing.
+    return hash_equals((string) $stored_key, (string) $key);
 }
 
-// Add verification check to authenticate filter
+/**
+ * Whether the current request is non-interactive (API/CLI) and therefore must
+ * receive a WP_Error rather than an HTML redirect when verification fails.
+ */
+function academyafrica_is_non_interactive_request()
+{
+    if (defined('REST_REQUEST') && REST_REQUEST) {
+        return true;
+    }
+    if (defined('XMLRPC_REQUEST') && XMLRPC_REQUEST) {
+        return true;
+    }
+    if (defined('WP_CLI') && WP_CLI) {
+        return true;
+    }
+    if (wp_doing_ajax()) {
+        return true;
+    }
+    // Application passwords / HTTP Basic auth (e.g. over REST or XML-RPC).
+    if (!empty($_SERVER['PHP_AUTH_USER']) || !empty($_SERVER['HTTP_AUTHORIZATION'])) {
+        return true;
+    }
+    return false;
+}
+
+// Add verification check to authenticate filter. `is_verified` is the single
+// authoritative account-state flag; the legacy account_status/user_status path
+// has been removed (see #56).
 function verify_user_on_login($user, $username = '')
 {
-    if (!$user || is_wp_error($user)) {
+    if (!$user || is_wp_error($user) || !($user instanceof WP_User)) {
         return $user;
     }
 
-    $is_verified = get_user_meta($user->ID, 'is_verified', true);
-
-    if (!$is_verified) {
-        $activation_key = get_user_meta($user->ID, 'account_activation_key', true);
-        if (empty($activation_key)) {
-            $activation_key = generate_user_activation_key($user->ID);
-        }
-
-        send_activation_link($user->ID);
-
-        // Store the error message in a transient
-        set_transient('login_error_message', 'Please verify your account. Check your email for the verification link.', 30);
-
-        // Redirect to custom login page
-        wp_redirect(add_query_arg('verification', 'required', home_url('/login')));
-        exit;
+    if (get_user_meta($user->ID, 'is_verified', true)) {
+        return $user;
     }
 
-    return $user;
+    // Ensure a valid activation key exists, then (re)send the verification email.
+    $activation_key = get_user_meta($user->ID, 'account_activation_key', true);
+    if (empty($activation_key)) {
+        generate_user_activation_key($user->ID);
+    }
+    send_activation_link($user->ID);
+
+    // Non-interactive clients get a proper authentication error, not a redirect.
+    if (academyafrica_is_non_interactive_request()) {
+        return new WP_Error(
+            'account_unverified',
+            __('Your account is not verified. Please use the verification link sent to your email.', 'academyafrica')
+        );
+    }
+
+    set_transient('login_error_message', 'Please verify your account. Check your email for the verification link.', 30);
+    wp_safe_redirect(add_query_arg('verification', 'required', home_url('/login')));
+    exit;
 }
 
-// Change priority to run earlier
-remove_filter('authenticate', 'verify_user_on_login', 99);
 add_filter('authenticate', 'verify_user_on_login', 20);
 
-// Additional security to prevent unauthorized access
+// Additional guard to prevent an unverified session from surviving on the front
+// end (e.g. after a programmatic login). Interactive requests only.
 function check_verified_user_status()
 {
-    if (is_admin() || wp_doing_ajax() || (defined('REST_REQUEST') && REST_REQUEST) || (defined('WP_CLI') && WP_CLI)) {
+    if (is_admin() || academyafrica_is_non_interactive_request()) {
         return;
     }
 
     $user = wp_get_current_user();
     if ($user->ID && !get_user_meta($user->ID, 'is_verified', true)) {
         wp_logout();
-        wp_redirect(add_query_arg('verification', 'required', home_url('/login')));
+        wp_safe_redirect(add_query_arg('verification', 'required', home_url('/login')));
         exit;
     }
 }
 add_action('init', 'check_verified_user_status');
+
+/**
+ * Handle the account-activation link before any output is sent, then redirect
+ * with a status flag the login template renders. Replaces the previous logic
+ * that mutated state and redirected from inside the template (after output).
+ */
+function handle_account_activation()
+{
+    if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'GET') {
+        return;
+    }
+    if (!isset($_GET['action'], $_GET['token']) || $_GET['action'] !== 'account_activation') {
+        return;
+    }
+
+    $login_url = home_url('/login');
+    $token_data = decode_verification_token(sanitize_text_field(wp_unslash($_GET['token'])));
+
+    if (!$token_data) {
+        wp_safe_redirect(add_query_arg('activation', 'invalid', $login_url));
+        exit;
+    }
+
+    $user_id = absint($token_data['user_id']);
+
+    if (get_user_meta($user_id, 'is_verified', true)) {
+        wp_safe_redirect(add_query_arg('activation', 'already', $login_url));
+        exit;
+    }
+
+    if (is_activation_key_valid($user_id, $token_data['activation_key'])) {
+        update_user_meta($user_id, 'is_verified', true);
+        delete_user_meta($user_id, 'account_activation_key');
+        delete_user_meta($user_id, 'activation_key_expiry');
+        wp_safe_redirect(add_query_arg('activation', 'success', $login_url));
+        exit;
+    }
+
+    wp_safe_redirect(add_query_arg('activation', 'invalid', $login_url));
+    exit;
+}
+add_action('init', 'handle_account_activation');
+
+/**
+ * One-time migration: grandfather existing active users as verified so that
+ * turning on `is_verified` enforcement does not lock anyone out. An account is
+ * grandfathered when its legacy state was active (account_status == 'active' or
+ * wp_users.user_status == 0). Genuinely-pending accounts stay unverified.
+ */
+function academyafrica_migrate_account_verification()
+{
+    if (get_option('aa_verification_migrated_v1')) {
+        return;
+    }
+
+    global $wpdb;
+    $batch = 500;
+
+    // 1. Users whose legacy meta marked them active.
+    $paged = 1;
+    do {
+        $ids = get_users(array(
+            'fields'     => 'ID',
+            'number'     => $batch,
+            'paged'      => $paged,
+            'meta_key'   => 'account_status',
+            'meta_value' => 'active',
+        ));
+        foreach ($ids as $id) {
+            if (!get_user_meta($id, 'is_verified', true)) {
+                update_user_meta($id, 'is_verified', true);
+            }
+        }
+        $paged++;
+    } while (count($ids) === $batch);
+
+    // 2. Users with an active core status (user_status = 0) — covers admins and
+    //    older accounts created before the custom meta existed.
+    $offset = 0;
+    do {
+        $ids = $wpdb->get_col($wpdb->prepare(
+            "SELECT ID FROM {$wpdb->users} WHERE user_status = 0 LIMIT %d OFFSET %d",
+            $batch,
+            $offset
+        ));
+        foreach ($ids as $id) {
+            if (!get_user_meta($id, 'is_verified', true)) {
+                update_user_meta($id, 'is_verified', true);
+            }
+        }
+        $offset += $batch;
+    } while (count($ids) === $batch);
+
+    update_option('aa_verification_migrated_v1', time());
+}
+add_action('admin_init', 'academyafrica_migrate_account_verification');
+
+/**
+ * Social sign-ups (Google, etc.) authenticate an already-verified email, so mark
+ * the account verified and suppress the standard activation email for them.
+ */
+function academyafrica_suppress_activation_for_social($profile_data = null)
+{
+    remove_action('user_register', 'send_activation_link', 10);
+}
+add_action('the_champ_before_registration', 'academyafrica_suppress_activation_for_social', 10, 1);
+
+function academyafrica_mark_social_user_verified($user_id)
+{
+    if ($user_id) {
+        update_user_meta($user_id, 'is_verified', true);
+    }
+}
+add_action('the_champ_user_successfully_created', 'academyafrica_mark_social_user_verified', 10, 1);
 
 function set_html_content_type()
 {
@@ -352,6 +496,10 @@ function decode_verification_token($token)
 function send_activation_link($user_id)
 {
     if ($user_id) {
+        // Already-verified accounts never need an activation email.
+        if (get_user_meta($user_id, 'is_verified', true)) {
+            return;
+        }
         $user = get_user_by('ID', $user_id);
         $sign_in_url = home_url() . '/login';
 

--- a/wp-content/themes/academyAfrica/functions.php
+++ b/wp-content/themes/academyAfrica/functions.php
@@ -297,25 +297,88 @@ function academyafrica_is_non_interactive_request()
     return false;
 }
 
-// Add verification check to authenticate filter. `is_verified` is the single
-// authoritative account-state flag; the legacy account_status/user_status path
-// has been removed (see #56).
+// `is_verified` is the single authoritative account-state flag; the legacy
+// account_status/user_status path has been removed (see #56).
+
+/**
+ * Whether is_verified enforcement is active. Enforcement only turns on once the
+ * one-time grandfathering migration has completed, so a deploy can never lock
+ * out legitimate users (including admins) before their accounts are migrated
+ * — which would otherwise deadlock, since running the migration itself requires
+ * an admin to be able to log in (#56 review).
+ */
+function academyafrica_verification_enforced()
+{
+    return (bool) get_option('aa_verification_migrated_v1');
+}
+
+/**
+ * Roles that are always allowed through the pre-enforcement grandfather fallback
+ * so staff/admins can bootstrap and run the migration. Filterable.
+ *
+ * @return string[]
+ */
+function academyafrica_privileged_roles()
+{
+    return (array) apply_filters('academyafrica_privileged_roles', array('administrator', 'editor', 'author'));
+}
+
+/**
+ * Narrow legacy-state fallback, consulted ONLY before enforcement is active: an
+ * account the migration would grandfather (explicit legacy account_status of
+ * 'active', or a privileged role) is allowed through so it isn't locked out in
+ * the window before the migration runs.
+ */
+function academyafrica_user_is_grandfathered($user_id)
+{
+    if ('active' === get_user_meta($user_id, 'account_status', true)) {
+        return true;
+    }
+    $user = get_userdata($user_id);
+    return $user instanceof WP_User && (bool) array_intersect((array) $user->roles, academyafrica_privileged_roles());
+}
+
+/**
+ * The single verification predicate used by every enforcement point (login,
+ * session guard, application passwords) so they can never disagree.
+ */
+function academyafrica_user_passes_verification($user_id)
+{
+    if (get_user_meta($user_id, 'is_verified', true)) {
+        return true;
+    }
+    if (!academyafrica_verification_enforced() && academyafrica_user_is_grandfathered($user_id)) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Send the activation email at most once per cooldown window per user, so a
+ * caller with valid credentials for an unverified account can't trigger mail on
+ * every attempt (#56 review).
+ */
+function academyafrica_maybe_send_activation_link($user_id)
+{
+    $key = 'aa_activation_sent_' . (int) $user_id;
+    if (get_transient($key)) {
+        return;
+    }
+    set_transient($key, 1, 10 * MINUTE_IN_SECONDS);
+    send_activation_link($user_id);
+}
+
 function verify_user_on_login($user, $username = '')
 {
     if (!$user || is_wp_error($user) || !($user instanceof WP_User)) {
         return $user;
     }
 
-    if (get_user_meta($user->ID, 'is_verified', true)) {
+    if (academyafrica_user_passes_verification($user->ID)) {
         return $user;
     }
 
-    // Ensure a valid activation key exists, then (re)send the verification email.
-    $activation_key = get_user_meta($user->ID, 'account_activation_key', true);
-    if (empty($activation_key)) {
-        generate_user_activation_key($user->ID);
-    }
-    send_activation_link($user->ID);
+    academyafrica_maybe_send_activation_link($user->ID);
 
     // Non-interactive clients get a proper authentication error, not a redirect.
     if (academyafrica_is_non_interactive_request()) {
@@ -332,8 +395,28 @@ function verify_user_on_login($user, $username = '')
 
 add_filter('authenticate', 'verify_user_on_login', 20);
 
+// Application-password authentication resolves the user via determine_current_user
+// → wp_authenticate_application_password(), which does NOT run the `authenticate`
+// chain that verify_user_on_login() is on. Enforce the same policy on that path
+// so an unverified account with an app password can't authenticate (#56 review).
+function academyafrica_enforce_verification_app_password($error, $user)
+{
+    if ($user instanceof WP_User && !academyafrica_user_passes_verification($user->ID)) {
+        if (!is_wp_error($error)) {
+            $error = new WP_Error();
+        }
+        $error->add(
+            'account_unverified',
+            __('Your account is not verified. Please use the verification link sent to your email.', 'academyafrica')
+        );
+    }
+    return $error;
+}
+add_filter('wp_authenticate_application_password_errors', 'academyafrica_enforce_verification_app_password', 10, 2);
+
 // Additional guard to prevent an unverified session from surviving on the front
-// end (e.g. after a programmatic login). Interactive requests only.
+// end (e.g. after a programmatic login). Interactive requests only, and mirrors
+// the login predicate exactly.
 function check_verified_user_status()
 {
     if (is_admin() || academyafrica_is_non_interactive_request()) {
@@ -341,7 +424,7 @@ function check_verified_user_status()
     }
 
     $user = wp_get_current_user();
-    if ($user->ID && !get_user_meta($user->ID, 'is_verified', true)) {
+    if ($user->ID && !academyafrica_user_passes_verification($user->ID)) {
         wp_logout();
         wp_safe_redirect(add_query_arg('verification', 'required', home_url('/login')));
         exit;
@@ -392,62 +475,110 @@ function handle_account_activation()
 add_action('init', 'handle_account_activation');
 
 /**
- * One-time migration: grandfather existing active users as verified so that
- * turning on `is_verified` enforcement does not lock anyone out. An account is
- * grandfathered when its legacy state was active (account_status == 'active' or
- * wp_users.user_status == 0). Genuinely-pending accounts stay unverified.
+ * One-time migration: grandfather existing users as verified so that turning on
+ * `is_verified` enforcement doesn't lock anyone out.
+ *
+ * An account is grandfathered only on signals that carry real meaning in this
+ * install: an explicit legacy account_status of 'active', or a privileged role.
+ * wp_users.user_status is deliberately NOT used — wp_insert_user() never
+ * persisted the `user_status => 1` that registration passed, so it is 0 for
+ * every user (including never-activated ones), which would verify pending
+ * accounts (#56 review).
+ *
+ * These signals select a small set (a few hundred), so the backfill is fast and
+ * done per user (proper cache invalidation, retryable). Prefer running it via
+ * WP-CLI (`wp academyafrica migrate-verification`) before enabling enforcement;
+ * an admin_init fallback runs it for the first capable admin otherwise.
+ *
+ * @param bool $force Bypass the completed flag and stale lock (WP-CLI).
+ * @return bool True on success (completion recorded); false if it did not run
+ *              or failed (left retryable).
  */
-function academyafrica_migrate_account_verification()
+function academyafrica_migrate_account_verification($force = false)
 {
-    if (get_option('aa_verification_migrated_v1')) {
-        return;
+    if (!$force && get_option('aa_verification_migrated_v1')) {
+        return true;
     }
 
-    // Keep this off the hot path: skip background/Heartbeat/cron requests and
-    // only run when a capable admin is actually driving an admin page view.
-    if (wp_doing_ajax() || wp_doing_cron() || !current_user_can('manage_options')) {
-        return;
+    // Atomic lock: add_option() fails if the row already exists, so concurrent
+    // runs can't both proceed (no check-then-set race). A crashed run leaves the
+    // lock; clear it with the WP-CLI --force flag.
+    if (!$force && false === add_option('aa_verification_migration_lock', time(), '', 'no')) {
+        return false;
     }
-
-    // Lock so that a request which dies mid-migration (this site has known
-    // memory pressure) cannot re-trigger the full scan on every admin request.
-    if (get_transient('aa_verification_migration_lock')) {
-        return;
-    }
-    set_transient('aa_verification_migration_lock', 1, 5 * MINUTE_IN_SECONDS);
 
     global $wpdb;
 
-    // Grandfather set: legacy state was active (user_status = 0 OR
-    // account_status meta == 'active') and the user has no is_verified meta yet.
-    // Done set-based in SQL so we never load tens of thousands of users/meta
-    // into PHP memory (this install has 50k+ users).
-    $where = "(u.user_status = 0 OR EXISTS (
-                  SELECT 1 FROM {$wpdb->usermeta} a
-                  WHERE a.user_id = u.ID AND a.meta_key = 'account_status' AND a.meta_value = 'active'
-              ))
-              AND NOT EXISTS (
-                  SELECT 1 FROM {$wpdb->usermeta} m
-                  WHERE m.user_id = u.ID AND m.meta_key = 'is_verified'
-              )";
-
-    // Capture affected IDs (ints only — lightweight) so we can surgically clear
-    // their meta cache after the write instead of flushing the whole cache.
-    $ids = $wpdb->get_col("SELECT u.ID FROM {$wpdb->users} u WHERE {$where}");
-
-    $wpdb->query(
-        "INSERT INTO {$wpdb->usermeta} (user_id, meta_key, meta_value)
-         SELECT u.ID, 'is_verified', '1' FROM {$wpdb->users} u WHERE {$where}"
+    // Set A — explicit legacy "active" accounts (small: a few hundred).
+    $active_ids = $wpdb->get_col(
+        $wpdb->prepare(
+            "SELECT user_id FROM {$wpdb->usermeta} WHERE meta_key = %s AND meta_value = %s",
+            'account_status',
+            'active'
+        )
     );
-
-    foreach ($ids as $id) {
-        wp_cache_delete((int) $id, 'user_meta');
+    if ('' !== $wpdb->last_error) {
+        error_log('academyafrica verification migration: query failed: ' . $wpdb->last_error);
+        delete_option('aa_verification_migration_lock');
+        return false; // leave retryable; do NOT record completion
     }
 
+    // Set B — privileged roles that must retain access.
+    $priv_ids = get_users(array(
+        'role__in' => academyafrica_privileged_roles(),
+        'fields'   => 'ID',
+        'number'   => -1,
+    ));
+
+    $ids = array_values(array_unique(array_map('intval', array_merge((array) $active_ids, (array) $priv_ids))));
+
+    $verified = 0;
+    foreach ($ids as $id) {
+        if (get_user_meta($id, 'is_verified', true)) {
+            continue;
+        }
+        // update_user_meta returns false on failure (and true/meta_id on success);
+        // it also invalidates the user's meta cache for us.
+        if (false !== update_user_meta($id, 'is_verified', true)) {
+            $verified++;
+        }
+    }
+
+    // Only record completion after the work is done.
     update_option('aa_verification_migrated_v1', time());
-    delete_transient('aa_verification_migration_lock');
+    update_option('aa_verification_migrated_v1_count', $verified);
+    delete_option('aa_verification_migration_lock');
+
+    return true;
 }
-add_action('admin_init', 'academyafrica_migrate_account_verification');
+
+// Fallback trigger: run once for the first capable admin if it wasn't already
+// run via WP-CLI. The grandfather set is small, so this is safe on admin_init.
+add_action('admin_init', function () {
+    if (get_option('aa_verification_migrated_v1')) {
+        return;
+    }
+    if (wp_doing_ajax() || wp_doing_cron() || !current_user_can('manage_options')) {
+        return;
+    }
+    academyafrica_migrate_account_verification();
+});
+
+// Preferred, deployment-controlled path: run before enabling enforcement.
+if (defined('WP_CLI') && WP_CLI) {
+    WP_CLI::add_command('academyafrica migrate-verification', function ($args, $assoc_args) {
+        $force = isset($assoc_args['force']);
+        $ok = academyafrica_migrate_account_verification($force);
+        if ($ok) {
+            WP_CLI::success(sprintf(
+                'Verification migration complete. Grandfathered %d user(s).',
+                (int) get_option('aa_verification_migrated_v1_count')
+            ));
+        } else {
+            WP_CLI::error('Migration did not run (locked or a query failed). Re-run with --force to clear a stale lock.');
+        }
+    });
+}
 
 /**
  * Social sign-ups (Google, etc.) authenticate an already-verified email, so mark

--- a/wp-content/themes/academyAfrica/functions.php
+++ b/wp-content/themes/academyAfrica/functions.php
@@ -417,42 +417,32 @@ function academyafrica_migrate_account_verification()
     set_transient('aa_verification_migration_lock', 1, 5 * MINUTE_IN_SECONDS);
 
     global $wpdb;
-    $batch = 500;
 
-    // 1. Users whose legacy meta marked them active.
-    $paged = 1;
-    do {
-        $ids = get_users(array(
-            'fields'     => 'ID',
-            'number'     => $batch,
-            'paged'      => $paged,
-            'meta_key'   => 'account_status',
-            'meta_value' => 'active',
-        ));
-        foreach ($ids as $id) {
-            if (!get_user_meta($id, 'is_verified', true)) {
-                update_user_meta($id, 'is_verified', true);
-            }
-        }
-        $paged++;
-    } while (count($ids) === $batch);
+    // Grandfather set: legacy state was active (user_status = 0 OR
+    // account_status meta == 'active') and the user has no is_verified meta yet.
+    // Done set-based in SQL so we never load tens of thousands of users/meta
+    // into PHP memory (this install has 50k+ users).
+    $where = "(u.user_status = 0 OR EXISTS (
+                  SELECT 1 FROM {$wpdb->usermeta} a
+                  WHERE a.user_id = u.ID AND a.meta_key = 'account_status' AND a.meta_value = 'active'
+              ))
+              AND NOT EXISTS (
+                  SELECT 1 FROM {$wpdb->usermeta} m
+                  WHERE m.user_id = u.ID AND m.meta_key = 'is_verified'
+              )";
 
-    // 2. Users with an active core status (user_status = 0) — covers admins and
-    //    older accounts created before the custom meta existed.
-    $offset = 0;
-    do {
-        $ids = $wpdb->get_col($wpdb->prepare(
-            "SELECT ID FROM {$wpdb->users} WHERE user_status = 0 LIMIT %d OFFSET %d",
-            $batch,
-            $offset
-        ));
-        foreach ($ids as $id) {
-            if (!get_user_meta($id, 'is_verified', true)) {
-                update_user_meta($id, 'is_verified', true);
-            }
-        }
-        $offset += $batch;
-    } while (count($ids) === $batch);
+    // Capture affected IDs (ints only — lightweight) so we can surgically clear
+    // their meta cache after the write instead of flushing the whole cache.
+    $ids = $wpdb->get_col("SELECT u.ID FROM {$wpdb->users} u WHERE {$where}");
+
+    $wpdb->query(
+        "INSERT INTO {$wpdb->usermeta} (user_id, meta_key, meta_value)
+         SELECT u.ID, 'is_verified', '1' FROM {$wpdb->users} u WHERE {$where}"
+    );
+
+    foreach ($ids as $id) {
+        wp_cache_delete((int) $id, 'user_meta');
+    }
 
     update_option('aa_verification_migrated_v1', time());
     delete_transient('aa_verification_migration_lock');

--- a/wp-content/themes/academyAfrica/functions.php
+++ b/wp-content/themes/academyAfrica/functions.php
@@ -403,6 +403,19 @@ function academyafrica_migrate_account_verification()
         return;
     }
 
+    // Keep this off the hot path: skip background/Heartbeat/cron requests and
+    // only run when a capable admin is actually driving an admin page view.
+    if (wp_doing_ajax() || wp_doing_cron() || !current_user_can('manage_options')) {
+        return;
+    }
+
+    // Lock so that a request which dies mid-migration (this site has known
+    // memory pressure) cannot re-trigger the full scan on every admin request.
+    if (get_transient('aa_verification_migration_lock')) {
+        return;
+    }
+    set_transient('aa_verification_migration_lock', 1, 5 * MINUTE_IN_SECONDS);
+
     global $wpdb;
     $batch = 500;
 
@@ -442,6 +455,7 @@ function academyafrica_migrate_account_verification()
     } while (count($ids) === $batch);
 
     update_option('aa_verification_migrated_v1', time());
+    delete_transient('aa_verification_migration_lock');
 }
 add_action('admin_init', 'academyafrica_migrate_account_verification');
 

--- a/wp-content/themes/academyAfrica/includes/functions/login.php
+++ b/wp-content/themes/academyAfrica/includes/functions/login.php
@@ -21,7 +21,6 @@ function custom_login_page()
     $reset_password_page = home_url('/login?action=lostpassword');
     $check_path = parse_url($_SERVER['REQUEST_URI'])['path'];
     check_register_action();
-    activate_new_user_action();
     if ($check_path == "/wp-login.php" && $_SERVER['REQUEST_METHOD'] == 'GET' && isset($_GET['action']) && $_GET['action'] == 'lostpassword') {
         wp_redirect($reset_password_page);
         exit;
@@ -58,57 +57,17 @@ function add_lost_password_link()
 {
     return '<a class="remember-me" href="/login?action=lostpassword">Lost Password?</a>';
 }
+// Surface a friendly error when a social (Google) sign-in fails. Account-state
+// enforcement now lives solely in verify_user_on_login()/check_verified_user_status()
+// keyed on the `is_verified` meta (see #56); the legacy account_status/user_status
+// path has been removed.
 function authenticate_user()
 {
-    if (!is_user_logged_in()) {
-        if (isset($_GET['login_type']) && $_GET['login_type'] === 'social') {
-            set_global_error("An error occurred while signing up with Google. Please try again with your username and password.");
-        }
-    }
-    $user_id = get_current_user_id();
-    $user = get_user_by('ID', $user_id);
-    if (!in_array($_SERVER['REMOTE_ADDR'], whitelist_address())) {
-        return $user;
-    } else {
-        if ($user instanceof WP_User) {
-            $account_status = get_user_meta($user->data->ID, 'account_status', true);
-            global $whitelist;
-            if (!in_array($_SERVER['REMOTE_ADDR'], whitelist_address())) {
-                if ($user->data->user_status == 1 || $account_status !== "active") {
-                    send_activation_link($user->data->ID);
-                    render_inactive(true);
-                }
-            }
-        } else {
-            render_inactive(false);
-        }
-    }
-}
-
-function restrict_user_status($user, $username, $password)
-{
-    if (!in_array($_SERVER['REMOTE_ADDR'], whitelist_address())) {
-        return $user;
-    } else {
-        if ($user instanceof WP_User) {
-            $account_status = get_user_meta($user->data->ID, 'account_status', true);
-            if ($user->data->user_status == 1 || $account_status !== "active") {
-                if (!isset($user->data->user_activation_key)) {
-                    send_activation_link($user->data->ID);
-                }
-                wp_logout();
-                return new WP_Error('authentication_failed', __('<strong>ERROR</strong>: Your account is not active.'));
-            } else {
-                return $user;
-            }
-        } else {
-            wp_logout();
-            return new WP_Error('authentication_failed', __('<strong>ERROR</strong>: Your account is not active.'));
-        }
+    if (!is_user_logged_in() && isset($_GET['login_type']) && $_GET['login_type'] === 'social') {
+        set_global_error("An error occurred while signing up with Google. Please try again with your username and password.");
     }
 }
 
 add_action('init', 'authenticate_user');
-add_filter('authenticate', 'restrict_user_status', 20, 3);
 add_action('init', 'custom_login_page');
 add_action('login_form_middle', 'add_lost_password_link');

--- a/wp-content/themes/academyAfrica/includes/functions/register.php
+++ b/wp-content/themes/academyAfrica/includes/functions/register.php
@@ -10,7 +10,8 @@ function check_register_action()
             'user_pass' => $_POST['password'],
             'user_nicename' => $_POST['firstName'] . $_POST['lastName'],
             'user_login' => $_POST['email'],
-            'user_status' => 1,
+            // NB: wp_insert_user() does not persist user_status, so it is not a
+            // reliable activation signal; verification is tracked via is_verified.
         );
         $new_user = wp_insert_user($user);
         if (is_wp_error($new_user)) {

--- a/wp-content/themes/academyAfrica/includes/functions/register.php
+++ b/wp-content/themes/academyAfrica/includes/functions/register.php
@@ -23,24 +23,10 @@ function check_register_action()
     }
 }
 
-function activate_new_user_action()
-{
-    if ($_SERVER['REQUEST_METHOD'] === 'GET' && ((isset($_GET['action'])) && $_GET['action'] === 'account_activation') && (isset($_GET['key'])) && (isset($_GET['user_id']))) {
-        $user_id = $_GET['user_id'];
-        $code = $_GET['key'];
-        global $wpdb;
-        $user = get_user_by('ID', $user_id);
-        update_user_meta($user_id, 'account_status', "active");
-        $wpdb->update(
-            'wp_users',
-            array('user_status' => 0),
-            array(
-                'ID' => $user_id,
-                'user_activation_key' => $code
-            ),
-        );
-    }
-}
+// Legacy activate_new_user_action() removed (#56): account activation is now
+// handled by handle_account_activation() on `init`, keyed on the signed token +
+// `is_verified` meta, instead of an unvalidated ?key=&user_id= wp_users write.
+
 function academyafrica_customize_register($wp_customize)
 {
     // Section for Profile Settings

--- a/wp-content/themes/academyAfrica/template-parts/login.php
+++ b/wp-content/themes/academyAfrica/template-parts/login.php
@@ -22,34 +22,20 @@ if (isset($_GET['email_sent'])) {
         'type' => 'info'
     ));
 } else {
-    if (isset($_GET['action']) && $_GET['action'] === 'account_activation' && isset($_GET['token'])) {
-        $token_data = decode_verification_token($_GET['token']);
-        // xdebug_break();
-
-        if ($token_data) {
-            $is_verified = get_user_meta($token_data['user_id'], 'is_verified', true);
-
-            if ($is_verified) {
-                get_template_part('template-parts/message-bar', 'template', array(
-                    'message' => academyafrica_translate('Your account is already verified. Please proceed to login.'),
-                    'type' => 'info'
-                ));
-                wp_redirect(home_url('/'));
-            } else if (is_activation_key_valid($token_data['user_id'], $token_data['activation_key'])) {
-                update_user_meta($token_data['user_id'], 'is_verified', true);
-                delete_user_meta($token_data['user_id'], 'account_activation_key');
-                delete_user_meta($token_data['user_id'], 'activation_key_expiry');
-
-                get_template_part('template-parts/message-bar', 'template', array(
-                    'message' => academyafrica_translate('Account activated successfully. You can now proceed to login.'),
-                    'type' => 'success'
-                ));
-            } else {
-                get_template_part('template-parts/message-bar', 'template', array(
-                    'message' => academyafrica_translate('Invalid or expired activation link. Please request a new one.'),
-                    'type' => 'error'
-                ));
-            }
+    // Account activation itself is processed before output in
+    // handle_account_activation() (#56); here we only render its outcome.
+    if (isset($_GET['activation'])) {
+        $activation = sanitize_key(wp_unslash($_GET['activation']));
+        if ($activation === 'success') {
+            get_template_part('template-parts/message-bar', 'template', array(
+                'message' => academyafrica_translate('Account activated successfully. You can now proceed to login.'),
+                'type' => 'success'
+            ));
+        } elseif ($activation === 'already') {
+            get_template_part('template-parts/message-bar', 'template', array(
+                'message' => academyafrica_translate('Your account is already verified. Please proceed to login.'),
+                'type' => 'info'
+            ));
         } else {
             get_template_part('template-parts/message-bar', 'template', array(
                 'message' => academyafrica_translate('Invalid or expired activation link. Please request a new one.'),


### PR DESCRIPTION
## Summary

Addresses **#56** (P1). The theme had **three overlapping account-state models** that disagreed with each other, leaving existing users (and admins) at risk of lockout. This consolidates everything onto a single authoritative flag — the **`is_verified`** user meta — and removes the legacy paths.

### Changes
- **Remove legacy enforcement:** the `account_status` / `wp_users.user_status` checks in `authenticate_user` and `restrict_user_status`, plus the unvalidated `activate_new_user_action()` that wrote the `wp_users` table straight from `?key=&user_id=`.
- **Activation before output:** new `handle_account_activation()` on `init` validates the token and redirects with a status flag; `template-parts/login.php` is now **render-only** (the old code mutated state and `wp_redirect`ed *after* output, so the redirect silently failed).
- **Context-aware login gate:** `verify_user_on_login` returns a `WP_Error` for REST / XML-RPC / application-password / CLI requests instead of an HTML redirect + `exit`. `check_verified_user_status` also bails on XML-RPC.
- **Hardening:** activation keys compared with `hash_equals`; activation email skipped for already-verified users.
- **Social sign-ups:** Google/social users are marked verified via `the_champ_user_successfully_created`, and their activation email is suppressed via `the_champ_before_registration`.

### Migration (no lockouts)
One-time, idempotent migration on `admin_init`, guarded by the `aa_verification_migrated_v1` option: grandfathers every user whose legacy state was active (`account_status == 'active'` **or** `wp_users.user_status == 0`, which covers admins/older accounts) as `is_verified = true`. Genuinely-pending accounts stay unverified. Batched to avoid memory issues.

## Verification
- `php -l -d short_open_tag=Off` passes on all changed files (preserves #45).
- **Requires staging (live WP + DB, not runnable in-repo):**
  - Migration dry-run on a DB snapshot: all previously-active users + admins gain `is_verified`; pending accounts remain unverified; second run is a no-op.
  - No admin/existing user is locked out post-migration (no logout loop).
  - Activation: valid token verifies + redirects before output; reused → "already verified"; expired/invalid → error message.
  - API: unverified user on REST/XML-RPC/app-password gets a 401 `WP_Error`, not an HTML redirect.

## Notes
- Token signing beyond `hash_equals` is tracked in the private advisory referenced by #58; this PR keeps the existing token shape.
- Follow-up **#54** (registration/login/password-reset flow repair) builds on this branch.

Refs #58