### PR TITLE
fix(auth): repair registration, login, and password-reset flows (#54)

### DIFF
--- a/wp-content/themes/academyAfrica/functions.php
+++ b/wp-content/themes/academyAfrica/functions.php
@@ -202,8 +202,10 @@ add_action('user_register', 'send_activation_link', 10, 1);
 function redirect_logged_in_users()
 {
     if (!is_admin() && is_page('login') && is_user_logged_in()) {
-        $redirect_url = isset($_GET['redirect_url']) ? $_GET['redirect_url'] : home_url('/');
-        wp_redirect($redirect_url);
+        $requested = isset($_GET['redirect_url']) ? wp_unslash($_GET['redirect_url']) : '';
+        // wp_safe_redirect + wp_validate_redirect confine the target to this host.
+        $redirect_url = wp_validate_redirect($requested, home_url('/'));
+        wp_safe_redirect($redirect_url);
         exit;
     }
 }

--- a/wp-content/themes/academyAfrica/includes/functions/login.php
+++ b/wp-content/themes/academyAfrica/includes/functions/login.php
@@ -4,37 +4,46 @@ function custom_login_page()
 {
     // Prefer our custom param, then WordPress's native redirect_to (used by
     // LearnDash, course pages, etc.), then fall back to the referer.
+    $redirect_url = '';
     if (isset($_GET['redirect_url']) && $_GET['redirect_url'] !== '') {
-        $redirect_url = $_GET['redirect_url'];
+        $redirect_url = wp_unslash($_GET['redirect_url']);
     } elseif (isset($_GET['redirect_to']) && $_GET['redirect_to'] !== '') {
-        $redirect_url = $_GET['redirect_to'];
-    } else {
-        $redirect_url = '';
+        $redirect_url = wp_unslash($_GET['redirect_to']);
     }
 
+    // Keep only the path (+ query) of the requested target so a caller cannot
+    // smuggle in an external host and turn login into an open redirect.
     $parsed_url = parse_url($redirect_url);
     $path = isset($parsed_url['path']) ? $parsed_url['path'] : '';
+    if (!empty($parsed_url['query'])) {
+        $path .= '?' . $parsed_url['query'];
+    }
 
-    $path_name = (!empty($path) && $path !== '/' && $path !== '/login') ? $redirect_url : "/learning-pathways";
-    $login_page = home_url("/login" . "?redirect_url=" . $path_name);
+    $path_name = (!empty($path) && strpos($path, '/') === 0 && $path !== '/' && $path !== '/login') ? $path : "/learning-pathways";
+    $login_page = add_query_arg('redirect_url', $path_name, home_url('/login'));
     $to_redirect = array("lostpassword");
     $reset_password_page = home_url('/login?action=lostpassword');
     $check_path = parse_url($_SERVER['REQUEST_URI'])['path'];
     check_register_action();
     if ($check_path == "/wp-login.php" && $_SERVER['REQUEST_METHOD'] == 'GET' && isset($_GET['action']) && $_GET['action'] == 'lostpassword') {
-        wp_redirect($reset_password_page);
+        wp_safe_redirect($reset_password_page);
         exit;
     }
     if ($check_path == "/wp-login.php" && $_SERVER['REQUEST_METHOD'] == 'GET' && isset($_GET['action']) && $_GET['action'] == 'rp') {
         if (isset($_GET["key"]) && isset($_GET["login"])) {
-            $reset_key = $_GET["key"];
-            wp_redirect(home_url('/login?action=rp&key=' . $reset_key) . '&login=' . $_GET["login"]);
+            // add_query_arg() encodes the values, producing a well-formed URL.
+            $target = add_query_arg(array(
+                'action' => 'rp',
+                'key'    => sanitize_text_field(wp_unslash($_GET["key"])),
+                'login'  => sanitize_text_field(wp_unslash($_GET["login"])),
+            ), home_url('/login'));
+            wp_safe_redirect($target);
         } else {
             $url = add_query_arg(array(
                 'action' => 'lostpassword',
                 'error_message' => 'Password Reset link is invalid.'
             ), home_url('/login'));
-            wp_redirect(home_url($url));
+            wp_safe_redirect($url);
         }
         exit;
     }
@@ -43,13 +52,16 @@ function custom_login_page()
         exit;
     }
     if ($check_path == "/wp-login.php" && $_SERVER['REQUEST_METHOD'] == 'GET' && (!isset($_GET['action']) || isset($to_redirect[$_GET['action']]))) {
-        wp_redirect($login_page);
+        wp_safe_redirect($login_page);
         exit;
     }
     if ($check_path == "/wp-login.php" && $_SERVER['REQUEST_METHOD'] == 'POST' && isset($_GET["wpe-login"])) {
-        $login = home_url("/login" . "?redirect_url=" . $path_name . "&login=failed");
-        wp_redirect($login);
-        // exit;
+        $login = add_query_arg(array(
+            'redirect_url' => $path_name,
+            'login'        => 'failed',
+        ), home_url('/login'));
+        wp_safe_redirect($login);
+        exit;
     }
 }
 

--- a/wp-content/themes/academyAfrica/includes/functions/password_reset.php
+++ b/wp-content/themes/academyAfrica/includes/functions/password_reset.php
@@ -6,7 +6,7 @@ function password_reset($user_email){
           'action' => 'lostpassword',
           'error_message' => 'Invalid email address.'
       ), home_url('/login'));
-      wp_redirect(home_url($url));
+      wp_safe_redirect($url);
       exit;
   }
 
@@ -19,7 +19,7 @@ function password_reset($user_email){
           'action' => 'lostpassword',
           'error_message' => 'No user was found with that email address.'
       ), home_url('/login'));
-      wp_redirect(home_url($url));
+      wp_safe_redirect($url);
       exit;
   }
 
@@ -30,7 +30,7 @@ function password_reset($user_email){
           'action' => 'lostpassword',
           'error_message' => 'An error occurred while generating the password reset key.'
       ), home_url('/login'));
-      wp_redirect(home_url($url));
+      wp_safe_redirect($url);
       exit;
   }
 

--- a/wp-content/themes/academyAfrica/includes/functions/register.php
+++ b/wp-content/themes/academyAfrica/includes/functions/register.php
@@ -1,27 +1,83 @@
 <?php
 
+function academyafrica_register_error_redirect($message)
+{
+    wp_safe_redirect(home_url('/login?action=register&error_message=' . urlencode($message)));
+    exit;
+}
+
 function check_register_action()
 {
-    if ($_SERVER['REQUEST_METHOD'] === 'POST' && (isset($_POST['action']) && $_POST['action'] === 'register')) {
-        $user = array(
-            'first_name' => $_POST['firstName'],
-            'last_name' => $_POST['lastName'],
-            'user_email' => $_POST['email'],
-            'user_pass' => $_POST['password'],
-            'user_nicename' => $_POST['firstName'] . $_POST['lastName'],
-            'user_login' => $_POST['email'],
-            // NB: wp_insert_user() does not persist user_status, so it is not a
-            // reliable activation signal; verification is tracked via is_verified.
-        );
-        $new_user = wp_insert_user($user);
-        if (is_wp_error($new_user)) {
-            wp_redirect(home_url('/login?action=register&error_message=' . urlencode($new_user->get_error_message())));
-        } else {
-            $success_message = "You have successfully created your account! To begin using this site you will need to activate your account via the email we have just sent to your address.";
-            wp_redirect(home_url('/login?action=register&success=' . urlencode($success_message)));
-        }
+    if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST' || ($_POST['action'] ?? '') !== 'register') {
+        return;
+    }
+
+    // CSRF protection.
+    if (
+        empty($_POST['academyafrica_register_nonce']) ||
+        !wp_verify_nonce($_POST['academyafrica_register_nonce'], 'academyafrica_register')
+    ) {
+        academyafrica_register_error_redirect(__('Your session has expired. Please try again.', 'academyafrica'));
+    }
+
+    // Honeypot: only bots populate this field. Pretend success so we don't
+    // reveal the trap.
+    if (!empty($_POST['academyafrica_hp'])) {
+        wp_safe_redirect(home_url('/login?action=register&success=' . urlencode(__('Please check your email to activate your account.', 'academyafrica'))));
         exit;
     }
+
+    // Per-IP abuse throttle.
+    $ip = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '';
+    $throttle_key = 'aa_register_throttle_' . md5($ip);
+    $attempts = (int) get_transient($throttle_key);
+    if ($attempts >= 5) {
+        academyafrica_register_error_redirect(__('Too many attempts. Please try again later.', 'academyafrica'));
+    }
+    set_transient($throttle_key, $attempts + 1, 10 * MINUTE_IN_SECONDS);
+
+    // Sanitize and validate input.
+    $first_name = isset($_POST['firstName']) ? sanitize_text_field(wp_unslash($_POST['firstName'])) : '';
+    $last_name  = isset($_POST['lastName']) ? sanitize_text_field(wp_unslash($_POST['lastName'])) : '';
+    $email      = isset($_POST['email']) ? sanitize_email(wp_unslash($_POST['email'])) : '';
+    $password   = isset($_POST['password']) ? (string) $_POST['password'] : '';
+    $confirm    = isset($_POST['confirm-password']) ? (string) $_POST['confirm-password'] : '';
+
+    if ($first_name === '' || $last_name === '' || $email === '' || $password === '') {
+        academyafrica_register_error_redirect(__('Please fill in all required fields.', 'academyafrica'));
+    }
+    if (!is_email($email)) {
+        academyafrica_register_error_redirect(__('Please enter a valid email address.', 'academyafrica'));
+    }
+    if (email_exists($email)) {
+        academyafrica_register_error_redirect(__('An account with that email already exists.', 'academyafrica'));
+    }
+    if (strlen($password) < 8) {
+        academyafrica_register_error_redirect(__('Password must be at least 8 characters long.', 'academyafrica'));
+    }
+    if ($confirm !== '' && $password !== $confirm) {
+        academyafrica_register_error_redirect(__('Passwords do not match.', 'academyafrica'));
+    }
+
+    // Account starts unverified; verification is enforced via `is_verified` (#56).
+    $new_user = wp_insert_user(array(
+        'first_name'    => $first_name,
+        'last_name'     => $last_name,
+        'user_email'    => $email,
+        'user_pass'     => $password,
+        'user_nicename' => sanitize_title($first_name . $last_name),
+        'user_login'    => $email,
+    ));
+
+    if (is_wp_error($new_user)) {
+        academyafrica_register_error_redirect($new_user->get_error_message());
+    }
+
+    // Activation email is sent by the user_register hook (send_activation_link).
+    delete_transient($throttle_key);
+    $success_message = __('You have successfully created your account! To begin using this site you will need to activate your account via the email we have just sent to your address.', 'academyafrica');
+    wp_safe_redirect(home_url('/login?action=register&success=' . urlencode($success_message)));
+    exit;
 }
 
 // Legacy activate_new_user_action() removed (#56): account activation is now

--- a/wp-content/themes/academyAfrica/template-parts/change-password.php
+++ b/wp-content/themes/academyAfrica/template-parts/change-password.php
@@ -24,7 +24,11 @@ if(isset($_POST["rp_key"])){
 <div style="min-height: calc(100vh - 620px);" class="login">
 <div class="content" id="login-modal-content">
         <?php
-        $url = home_url('/login?action=rp&key='.$_GET["key"]).'&login='.$_GET["login"];
+        $url = add_query_arg(array(
+            'action' => 'rp',
+            'key'    => sanitize_text_field(wp_unslash($_GET["key"] ?? '')),
+            'login'  => sanitize_text_field(wp_unslash($_GET["login"] ?? '')),
+        ), home_url('/login'));
         if(!$is_success) {
         ?>
         <header>
@@ -33,13 +37,13 @@ if(isset($_POST["rp_key"])){
         <p class="subtitle">
             <?php echo esc_html(academyafrica_translate('Enter your new password below or generate one')); ?>
         </p>
-        <form name="resetpassform" id="resetpassform" action="<?php echo $url ?>" method="post" autocomplete="off">
-			<input type="hidden" id="user_login" name="user_login" value="<?php echo $_GET["login"]?>" autocomplete="off">
+        <form name="resetpassform" id="resetpassform" action="<?php echo esc_url($url) ?>" method="post" autocomplete="off">
+			<input type="hidden" id="user_login" name="user_login" value="<?php echo esc_attr(wp_unslash($_GET["login"] ?? ''))?>" autocomplete="off">
             <label for="password"><?php echo esc_html(academyafrica_translate('Password')); ?></label>
             <input placeholder="<?php echo esc_attr(academyafrica_translate('Password')); ?>" name="pass1" type="password">
             <label for="pass2"><?php echo esc_html(academyafrica_translate('Confirm Password')); ?></label>
             <input placeholder="<?php echo esc_attr(academyafrica_translate('Password')); ?>" name="pass2" type="password">
-            <input type="text" hidden name="rp_key" value="<?php echo $_GET["key"]?>">
+            <input type="text" hidden name="rp_key" value="<?php echo esc_attr(wp_unslash($_GET["key"] ?? ''))?>">
             <button class="button primary" style="width: 100%; margin: 24px 0;" type="submit"><?php echo esc_html(academyafrica_translate('SAVE PASSWORD')); ?></button>
 		</form>
         <footer style="display: flex; justify-content: flex-end;" class="modal-footers">

--- a/wp-content/themes/academyAfrica/template-parts/password-reset.php
+++ b/wp-content/themes/academyAfrica/template-parts/password-reset.php
@@ -28,16 +28,16 @@ function get_full_url($path = '', $search = '')
             </p>
             <div style="display:flex; gap: 8px">
                 <span class="description"><?php echo esc_html(academyafrica_translate('You can')); ?> </span>
-                <form action="<?php echo wp_lostpassword_url() ?>" method="post">
-                    <input type="email" placeholder="<?php echo esc_attr(academyafrica_translate('Email')); ?>" id="user_login" name="user_login" value="<?php echo $_GET['user_login'] ?>" required hidden>
+                <form action="<?php echo esc_url(wp_lostpassword_url()) ?>" method="post">
+                    <input type="email" placeholder="<?php echo esc_attr(academyafrica_translate('Email')); ?>" id="user_login" name="user_login" value="<?php echo esc_attr(wp_unslash($_GET['user_login'] ?? '')) ?>" required hidden>
                     <input type="text" hidden name="pass_reset" value="pass-reset">
                     <button class="description" style="background: none; border: none; padding: 0; margin: 0; font: inherit; color: #0C1A81; text-decoration: none; cursor: pointer; display: inline;"
                         onmouseover="this.style.textDecoration='underline';"
                         onmouseout="this.style.textDecoration='none';">
                         <?php echo esc_html(academyafrica_translate('resend the reset link')); ?>
                     </button>
+                </form>
             </div>
-            </form>
             <span class="description"><?php echo esc_html(academyafrica_translate('or contact our support team for further assistance.')); ?></span>
 
         </div>
@@ -55,7 +55,7 @@ function get_full_url($path = '', $search = '')
                 <p id="login_error">
                 </p>
             </div>
-            <form action="<?php echo wp_lostpassword_url() ?>" method="post">
+            <form action="<?php echo esc_url(wp_lostpassword_url()) ?>" method="post">
                 <label for="email"><?php echo esc_html(academyafrica_translate('Email')); ?></label>
                 <input type="email" placeholder="<?php echo esc_attr(academyafrica_translate('Email')); ?>" id="user_login" name="user_login" required>
                 <input type="text" hidden name="pass_reset" value="pass-reset">

--- a/wp-content/themes/academyAfrica/template-parts/register.php
+++ b/wp-content/themes/academyAfrica/template-parts/register.php
@@ -22,7 +22,7 @@ if ($success) {
             <p class="text">
             </p>
             <p style="max-width: 400px; margin: 0;" class="description">
-                <?php echo $success ?>
+                <?php echo esc_html($success) ?>
             </p>
             <div class="actions">
                 <a class="button" href="/login">
@@ -64,11 +64,9 @@ if ($success) {
             <?php
             $error = get_url_param("error_message");
             if ($error) {
-            ?><div class="error_message"><?php
-                                            echo $error;
-                                            ?></div><?php
-                                                }
-                                                    ?>
+            ?><div class="error_message"><?php echo esc_html($error); ?></div><?php
+            }
+            ?>
             <?php
             $success_message = academyafrica_translate('You have successfully created your account! To begin using this site you will need to activate your account via the email we have just sent to your address.  Please check your email inbox or spam folder for an activation link.');
             $url = home_url('/login?action=register&success=' . urlencode($success_message));
@@ -92,6 +90,9 @@ if ($success) {
                 </div>
                 <div id="error-alert" style="color: red;"></div>
                 <input type="hidden" name="action" value="register">
+                <?php wp_nonce_field('academyafrica_register', 'academyafrica_register_nonce'); ?>
+                <?php // Honeypot: hidden from humans; bots that fill it are rejected server-side. ?>
+                <input type="text" name="academyafrica_hp" tabindex="-1" autocomplete="off" aria-hidden="true" style="position:absolute;left:-9999px;top:-9999px;height:0;width:0;opacity:0;" value="">
                 <?php echo do_shortcode('[bws_google_captcha]') ?>
                 <button class="button primary" style="width: 100%; margin: 24px 0;" type="submit" id="register"><?php echo esc_html(academyafrica_translate('SIGN UP')); ?></button>
                 <label class="mui-checkbox">


### PR DESCRIPTION
## Summary

Addresses **#54** (P1). Repairs the registration, login-redirect, and password-reset flows.

> **Stacked on #60 (#56).** Base is `fix/56-consolidate-account-verification`; it will retarget to `develop` automatically once #56 merges. Review #60 first.

### Registration hardening (`includes/functions/register.php`, `template-parts/register.php`)
- **CSRF nonce** (`wp_nonce_field` / `wp_verify_nonce`) and a **honeypot** field.
- **Server-side sanitize + validate** every field: names (`sanitize_text_field`), email (`sanitize_email` + `is_email` + `email_exists`), password length, confirm-password match — each with a friendly error redirect.
- **Per-IP throttle** via transient (5 attempts / 10 min).
- Drop the legacy `user_status = 1` seed (verification is now via `is_verified`, #56).

### Redirect safety (`includes/functions/login.php`, `functions.php`)
- Resolve `redirect_url` / `redirect_to` to a **same-host rooted path only**, closing an open-redirect (previously the full attacker-supplied URL was echoed into `redirect_url`).
- Harden the sink `redirect_logged_in_users` with `wp_validate_redirect` + `wp_safe_redirect`.
- Use `wp_safe_redirect` for all internal auth redirects; add the missing `exit` after the WPE-login redirect.

### Password reset (`includes/functions/*`, `template-parts/*`)
- Fix the **malformed reset URL** and the **double `home_url()`** wrap; build with `add_query_arg` so values are encoded.
- Fix the **mis-nested `<form>`/`<div>`** in `password-reset.php`.
- **Escape** echoed request data (`esc_attr` / `esc_url`) in the password-reset, change-password, and register templates.

## Verification
- `php -l -d short_open_tag=Off` passes on all changed files (preserves #45).
- **Requires staging (live WP):** registration rejects invalid/missing fields, bad nonce, and honeypot hits; valid signup creates an unverified user + one activation email; login-failure path is clean; reset request → email → confirmation all succeed with well-formed URLs; open-redirect attempt (`?redirect_url=https://evil.example`) stays on-site.

Refs #58