### PR TITLE
fix(learndash): restore topicless completion and certificate resilience (#46)

### DIFF
--- a/wp-content/themes/academyAfrica/includes/functions/learndash.php
+++ b/wp-content/themes/academyAfrica/includes/functions/learndash.php
@@ -4,6 +4,44 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+/**
+ * Return a course's assigned certificate post only when it exists and is
+ * published. Guards missing, deleted, or unpublished certificates so callers
+ * get a controlled null instead of a fatal on ->post_content (#46).
+ *
+ * @param int $course_id
+ * @return WP_Post|null
+ */
+function academyafrica_get_course_certificate_post($course_id)
+{
+    if (!$course_id || !function_exists('learndash_get_setting')) {
+        return null;
+    }
+
+    $certificate_id = learndash_get_setting($course_id, 'certificate');
+    if (empty($certificate_id)) {
+        return null;
+    }
+
+    $cert_post = get_post($certificate_id);
+    if (!($cert_post instanceof WP_Post) || 'publish' !== $cert_post->post_status) {
+        return null;
+    }
+
+    return $cert_post;
+}
+
+/**
+ * Whether a course has a usable (published) certificate assigned.
+ *
+ * @param int $course_id
+ * @return bool
+ */
+function academyafrica_course_has_certificate($course_id)
+{
+    return (bool) academyafrica_get_course_certificate_post($course_id);
+}
+
 function academyafrica_count_students($post_id)
 {
     if (function_exists('learndash_course_grid_count_students')) {

--- a/wp-content/themes/academyAfrica/includes/widgets/my_courses.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/my_courses.php
@@ -370,8 +370,12 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                             if (!empty($completed_courses['results'])) {
                                 foreach ($completed_courses['results'] as $key => $course) {
                                     $course_id = $course->post_id;
-                                    $certificate_id = learndash_get_setting($course_id, 'certificate');
-                                    $cert_post = get_post($certificate_id);
+                                    // Skip completed courses that have no published certificate
+                                    // rather than fataling on $cert_post->post_content below (#46).
+                                    $cert_post = academyafrica_get_course_certificate_post($course_id);
+                                    if (!$cert_post) {
+                                        continue;
+                                    }
                                     $title = get_the_title($course);
                                     $authors = get_coauthors($course_id);
                                     $first_name = get_the_author_meta('first_name', $authors[0]->ID);

--- a/wp-content/themes/academyAfrica/includes/widgets/my_courses.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/my_courses.php
@@ -360,22 +360,26 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                         </div>
                     <?php } ?>
                 </section>
-                <?php if (!empty($completed_courses['results'])) { ?>
+                <?php
+                // Only completed courses that have a published certificate belong in
+                // this section. Filter up front so the header never renders with zero
+                // cards, and so the loop body can assume a valid cert (#46 review).
+                $certificate_courses = array_filter(
+                    $completed_courses['results'] ?? array(),
+                    function ($course) {
+                        return (bool) academyafrica_get_course_certificate_post($course->post_id);
+                    }
+                );
+                if (!empty($certificate_courses)) { ?>
                     <section class="your-certificates">
                         <h4 class="your-certificates-title">
                             Your Certificates
                         </h4>
                         <div class="content">
                             <?php
-                            if (!empty($completed_courses['results'])) {
-                                foreach ($completed_courses['results'] as $key => $course) {
+                            foreach ($certificate_courses as $key => $course) {
                                     $course_id = $course->post_id;
-                                    // Skip completed courses that have no published certificate
-                                    // rather than fataling on $cert_post->post_content below (#46).
                                     $cert_post = academyafrica_get_course_certificate_post($course_id);
-                                    if (!$cert_post) {
-                                        continue;
-                                    }
                                     $title = get_the_title($course);
                                     $authors = get_coauthors($course_id);
                                     $first_name = get_the_author_meta('first_name', $authors[0]->ID);
@@ -442,7 +446,6 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
 
                             <?php
                                 }
-                            }
                             ?>
                         </div>
                         <hr class="divider">

--- a/wp-content/themes/academyAfrica/learndash/ld30/course.php
+++ b/wp-content/themes/academyAfrica/learndash/ld30/course.php
@@ -159,7 +159,10 @@ if (false === $orgs_data) {
 </style>
 <?php
 $is_cert = isset($_GET["certificate"]);
-if ($course_status == "Completed" && $is_cert) {
+// Only open the certificate experience when a published certificate actually
+// exists — otherwise a bookmarked/hand-built ?certificate URL would render it
+// for a cert-less course (#46 review).
+if ($course_status == "Completed" && $is_cert && academyafrica_course_has_certificate($course_id)) {
     get_template_part('template-parts/course_completed', null, array('course_id' => $course_id));
 } else {
 ?>

--- a/wp-content/themes/academyAfrica/learndash/ld30/course.php
+++ b/wp-content/themes/academyAfrica/learndash/ld30/course.php
@@ -213,9 +213,9 @@ if ($course_status == "Completed" && $is_cert) {
                     echo $cp_output;
                     ?>
                     <?php
-                    if ($course_status == "Completed") {
+                    if ($course_status == "Completed" && academyafrica_course_has_certificate($course_id)) {
                         $cert_label = function_exists('pll__') ? pll__('Download Certificate') : 'Download Certificate';
-                        echo "<a href='" . get_permalink($course_id) . "?certificate=true' class='pathways-link'>" . esc_html($cert_label) . "</a>";
+                        echo "<a href='" . esc_url(get_permalink($course_id) . '?certificate=true') . "' class='pathways-link'>" . esc_html($cert_label) . "</a>";
                     }
                     ?>
                 </div>

--- a/wp-content/themes/academyAfrica/learndash/ld30/lesson.php
+++ b/wp-content/themes/academyAfrica/learndash/ld30/lesson.php
@@ -149,24 +149,33 @@ do_action('qm/stop', 'lesson:init');
                 <div class="sfwd-lessons__footer">
                     <hr class="sfwd-lessons__navigation__divider" />
                     <?php
-                    if (!is_array($topics)) {
+                    // A topicless lesson is completed via its own button. A lesson
+                    // WITH topics is auto-completed once its topics are done
+                    // (LearnDash progression rules), so it shows no button here.
+                    if (empty($topics)) {
                         $complete_button = learndash_mark_complete($lesson);
                         if ($complete_button) {
                             echo "<div class='sfwd-lessons__footer__complete'>" . $complete_button . "</div>";
                         }
-                        if ($course_status == 'Completed') {
-                            echo "<div class='sfwd-lessons__footer__certificate'>";
-                            echo "<a href='" . esc_url($course_url . '?certificate=true') . "' class='certificate_download'>Download Certificate</a>";
-                            echo "</div>";
-                        }
+                    }
+                    // Certificate access on a completed course, independent of the
+                    // lesson's topic structure, and only when one is published.
+                    if ($course_status == 'Completed' && academyafrica_course_has_certificate($course_id)) {
+                        echo "<div class='sfwd-lessons__footer__certificate'>";
+                        echo "<a href='" . esc_url($course_url . '?certificate=true') . "' class='certificate_download'>Download Certificate</a>";
+                        echo "</div>";
+                    }
                     ?>
-                        <script>
-                            document.querySelector('.sfwd-mark-complete').addEventListener('submit', function(e) {
+                    <script>
+                        (function() {
+                            var form = document.querySelector('.sfwd-mark-complete');
+                            if (!form) return;
+                            form.addEventListener('submit', function(e) {
                                 var url = e.target.action.split('#')[0];
                                 e.target.action = url;
                             });
-                        </script>
-                    <?php } ?>
+                        })();
+                    </script>
                 </div>
             </div>
         </div>

--- a/wp-content/themes/academyAfrica/learndash/ld30/topic.php
+++ b/wp-content/themes/academyAfrica/learndash/ld30/topic.php
@@ -147,17 +147,21 @@ do_action('qm/stop', 'topic:init');
                     if ($complete_button) {
                         echo "<div class='sfwd-lessons__footer__complete'>" . $complete_button . "</div>";
                     }
-                    if ($course_status == 'Completed') {
+                    if ($course_status == 'Completed' && academyafrica_course_has_certificate($course_id)) {
                         echo "<div class='sfwd-lessons__footer__certificate'>";
                         echo "<a href='" . esc_url($course_url . '?certificate=true') . "' class='certificate_download'>Download Certificate</a>";
                         echo "</div>";
                     }
                     ?>
                     <script>
-                        document.querySelector('.sfwd-mark-complete').addEventListener('submit', function(e) {
-                            var url = e.target.action.split('#')[0];
-                            e.target.action = url;
-                        });
+                        (function() {
+                            var form = document.querySelector('.sfwd-mark-complete');
+                            if (!form) return;
+                            form.addEventListener('submit', function(e) {
+                                var url = e.target.action.split('#')[0];
+                                e.target.action = url;
+                            });
+                        })();
                     </script>
                 </div>
             </div>

--- a/wp-content/themes/academyAfrica/template-parts/course_completed.php
+++ b/wp-content/themes/academyAfrica/template-parts/course_completed.php
@@ -88,7 +88,7 @@ global $shortcode_tags;
                     <?php get_template_part('template-parts/social_share', 'template', array('message' => $share_message)); ?>
                 </div>
                 <div style="display: flex; gap: 16px; justify-content: center; margin-top: 16px; flex-direction: column;">
-                    <?php if (!empty($certificate_link)) : ?>
+                    <?php if ($cert_post && !empty($certificate_link)) : ?>
                     <a href="<?php echo esc_url($certificate_link) ?>" download>
                         <button class="button primary" id="download-certificate">
                             <svg width="17" height="17" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/wp-content/themes/academyAfrica/template-parts/course_completed.php
+++ b/wp-content/themes/academyAfrica/template-parts/course_completed.php
@@ -18,9 +18,10 @@ $certificate_course = get_the_title($course);
 $course_link = get_permalink($course_id);
 $company_name = "academy.Africa";
 $user_id = get_current_user_id();
-$certificate_link = learndash_get_course_certificate_link($args["course_id"], $user_id);
-$certificate_id = learndash_get_setting($course_id, 'certificate');
-$cert_post = get_post($certificate_id);
+$certificate_link = $course_id ? learndash_get_course_certificate_link($args["course_id"], $user_id) : '';
+// May be null when the course has no assigned certificate, or it was deleted
+// or unpublished. Callers below must guard before using it (#46).
+$cert_post = academyafrica_get_course_certificate_post($course_id);
 $user = array(
     "first_name" => get_user_meta($user_id, 'first_name', true),
     "last_name" => get_user_meta($user_id, 'last_name', true),
@@ -71,9 +72,11 @@ global $shortcode_tags;
     <h4 class="cfa-title">
         <?php echo $congratulations ?>
     </h4>
-    <div class="cert-pdf">
-        <?php echo do_shortcode($cert_post->post_content) ?>
-    </div>
+    <?php if ($cert_post) : ?>
+        <div class="cert-pdf">
+            <?php echo do_shortcode($cert_post->post_content) ?>
+        </div>
+    <?php endif; ?>
     <div class="content">
         <?php get_template_part('template-parts/certificate', 'template', array("academy_head" => $academy_head, "course" => array("date" => $completion_date, "name" => $certificate_course), "user" => $user)); ?>
         <div style="flex: 1; display: flex; justify-content: center;">
@@ -85,7 +88,8 @@ global $shortcode_tags;
                     <?php get_template_part('template-parts/social_share', 'template', array('message' => $share_message)); ?>
                 </div>
                 <div style="display: flex; gap: 16px; justify-content: center; margin-top: 16px; flex-direction: column;">
-                    <a href="<?php echo learndash_get_course_certificate_link($course_id) ?>" download>
+                    <?php if (!empty($certificate_link)) : ?>
+                    <a href="<?php echo esc_url($certificate_link) ?>" download>
                         <button class="button primary" id="download-certificate">
                             <svg width="17" height="17" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg">
                                 <g id="Icon">
@@ -97,6 +101,7 @@ global $shortcode_tags;
                             <?php echo esc_html(academyafrica_translate('Download')); ?>
                         </button>
                     </a>
+                    <?php endif; ?>
                     <a href="<?php echo get_permalink($course_id) ?>">
                         <button class="button primary">
                             <?php echo esc_html(academyafrica_translate('View Course')); ?>


### PR DESCRIPTION
## Summary

Addresses **#46** (P1) — audit findings 15 (progression) and 16 (certificates).

### Progression (finding 15)
- `lesson.php` gated the **Mark Complete** control on `if (!is_array($topics))`, but `$topics` is always an array (`learndash_get_topic_list(...) ?: []`), so the condition is **always false** and **topicless lessons could never be completed**. Now gated on `empty($topics)`: topicless lessons render their own button; lessons *with* topics auto-complete once their topics are done (documented LearnDash rule).
- Guarded the completion **DOM listeners** in `lesson.php` and `topic.php` — they did `document.querySelector('.sfwd-mark-complete').addEventListener(...)` with no null check, throwing a JS error whenever no form is rendered (already-completed step). Now wrapped in a null guard.

### Certificates (finding 16)
- New helpers `academyafrica_get_course_certificate_post()` / `academyafrica_course_has_certificate()` return a **published** certificate post or `null`, guarding missing / deleted / unpublished certificates.
- `template-parts/course_completed.php` previously fataled on `$cert_post->post_content` when a course had no assigned certificate (`get_post('')` → `null`). The preview and the download link are now guarded.
- **My Courses** skips completed courses without a published certificate instead of fataling; the “Download Certificate” links in `course.php`, `lesson.php`, and `topic.php` only render when a certificate actually exists.

## Verification
- `php -l` clean on all changed files.
- Ran the guard against the local DB: **5 of 36 courses have no certificate** — the helper returns `null` for those (previously a fatal), `null` for bogus IDs, and a published `WP_Post` when one exists.
- Manual regression still needed on staging: complete a topicless lesson; complete a lesson-with-topics; view a completed course whose certificate is missing/unpublished (controlled empty state, no warning).

Refs #58