### PR TITLE
fix(events): harden event rendering and bound filter queries (#57)

### DIFF
--- a/wp-content/themes/academyAfrica/includes/widgets/events.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/events.php
@@ -256,6 +256,12 @@ class Academy_Africa_Events  extends \Elementor\Widget_Base
             'update_post_term_cache' => false,
         )) : array();
 
+        // fields => 'ids' skips meta priming; batch it so the per-event
+        // get_post_meta() calls below are served from one cache read (#57 review).
+        if (!empty($event_ids)) {
+            update_meta_cache('post', $event_ids);
+        }
+
         $output = array();
         foreach ($filter_options as $option) {
             if ($option == "date") {

--- a/wp-content/themes/academyAfrica/includes/widgets/events.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/events.php
@@ -107,10 +107,13 @@ class Academy_Africa_Events  extends \Elementor\Widget_Base
         if ($query->have_posts()) {
             while ($query->have_posts()) {
                 $query->the_post();
-                $user_data = get_userdata(get_post_meta(get_the_ID(), 'speaker', true));
+                $speaker_meta = get_post_meta(get_the_ID(), 'speaker', true);
+                $user_data = $speaker_meta ? get_userdata($speaker_meta) : false;
                 $raw_date = get_post_meta(get_the_ID(), 'date', true);
-                $date = date_format(date_create($raw_date), 'd/m/Y');
+                // Safe: never fatals on a missing/malformed date (#57).
+                $date = academyafrica_format_event_date($raw_date, 'd/m/Y');
                 $countries = get_post_meta(get_the_ID(), 'countries', true);
+                $has_countries = is_array($countries) && !empty($countries);
                 $post_data = array(
                     'title' => get_the_title(),
                     'speaker' => $user_data ? $user_data->display_name : 'Unknown Speaker',
@@ -119,10 +122,10 @@ class Academy_Africa_Events  extends \Elementor\Widget_Base
                     'date' => $date,
                     'time' => get_post_meta(get_the_ID(), 'time', true) . ' ' . "GMT +00:00",
                     'image' => get_the_post_thumbnail_url(get_the_ID(), 'full'),
-                    'country_code' => isset($countries) ? country_flag_emoji($countries[0]) : country_flag_emoji("ZA"),
+                    'country_code' => $has_countries ? country_flag_emoji($countries[0]) : country_flag_emoji("ZA"),
                     'language' => get_post_meta(get_the_ID(), 'language', true),
                     'post_url' => get_permalink(get_the_ID()),
-                    'countries' => get_post_meta(get_the_ID(), 'countries', true)
+                    'countries' => $has_countries ? $countries : array()
                 );
 
                 $result[] = $post_data;
@@ -227,69 +230,78 @@ class Academy_Africa_Events  extends \Elementor\Widget_Base
     {
         $settings = $this->get_settings_for_display();
         $filter_options = $settings['filter_options'];
+        if (empty($filter_options)) {
+            return array();
+        }
+
+        // Cache the whole result; invalidated by the version bump on event save.
+        $cache_key = 'aa_event_filters_' . academyafrica_event_filters_version()
+            . '_' . md5(wp_json_encode($filter_options));
+        $cached = get_transient($cache_key);
+        if (false !== $cached) {
+            return $cached;
+        }
+
+        // Load event IDs ONCE and derive every meta-based dimension from them,
+        // instead of running an unbounded query per filter dimension (#57).
+        $needs_events = (bool) array_filter($filter_options, function ($o) {
+            return $o !== 'date';
+        });
+        $event_ids = $needs_events ? get_posts(array(
+            'post_type'              => 'event',
+            'post_status'            => 'publish',
+            'posts_per_page'         => -1,
+            'fields'                 => 'ids',
+            'no_found_rows'          => true,
+            'update_post_term_cache' => false,
+        )) : array();
+
         $output = array();
-        if (!empty($filter_options)) {
-            foreach ($filter_options as $option) {
-                if ($option == "date") {
-                    $output[] = array(
-                        "title" => "Date",
-                        "name" => "date",
-                        "options" => array(
-                            "All" => "all",
-                            "This Week" => "week",
-                            "This Month" => "month",
-                            "Closed" => "closed"
-                        )
-                    );
+        foreach ($filter_options as $option) {
+            if ($option == "date") {
+                $output[] = array(
+                    "title" => "Date",
+                    "name" => "date",
+                    "options" => array(
+                        "All" => "all",
+                        "This Week" => "week",
+                        "This Month" => "month",
+                        "Closed" => "closed"
+                    )
+                );
+                continue;
+            }
+
+            $options = array();
+            foreach ($event_ids as $post_id) {
+                if ($option == "country") {
+                    $values = get_post_meta($post_id, "countries", true);
+                    if (!is_array($values)) {
+                        continue;
+                    }
+                    foreach ($values as $field_name) {
+                        $c_name = get_country_code($field_name);
+                        $opt = (is_array($c_name) && isset($c_name["name"])) ? $c_name["name"] : "";
+                        if ($opt !== "") {
+                            $options[$opt] = $field_name;
+                        }
+                    }
                 } else {
-                    $args = array(
-                        'post_type' => 'event',
-                        'posts_per_page' => -1,
-                    );
-                    $query = new WP_Query($args);
-                    $options = array();
-                    if ($option == "country") {
-                        if ($query->have_posts()) {
-                            while ($query->have_posts()) {
-                                $query->the_post();
-                                $post_id = get_the_ID();
-                                $values = get_post_meta($post_id, "countries", true);
-                                if (isset($values)) {
-                                    foreach ($values as $field_name) {
-                                        $c_name = get_country_code($field_name);
-                                        $opt = isset($c_name) ? $c_name["name"] : "";
-                                        $options[$opt] = $field_name;
-                                    }
-                                }
-                            }
-                            wp_reset_postdata();
-                        }
-                        $output[] = array(
-                            "title" => $this->filter_labels()[$option] ?? $option,
-                            "name" => $option,
-                            "options" => $options
-                        );
-                    } else {
-                        if ($query->have_posts()) {
-                            while ($query->have_posts()) {
-                                $query->the_post();
-                                $post_id = get_the_ID();
-                                $field_name = get_post_meta($post_id, $option, true);
-                                if ($field_name) {
-                                    $options[$field_name] = $field_name;
-                                }
-                            }
-                            wp_reset_postdata();
-                        }
-                        $output[] = array(
-                            "title" => $this->filter_labels()[$option] ?? $option,
-                            "name" => $option,
-                            "options" => $options
-                        );
+                    $field_name = get_post_meta($post_id, $option, true);
+                    if (!empty($field_name) && is_scalar($field_name)) {
+                        $options[$field_name] = $field_name;
                     }
                 }
             }
+
+            $output[] = array(
+                "title" => $this->filter_labels()[$option] ?? $option,
+                "name" => $option,
+                "options" => $options
+            );
         }
+
+        set_transient($cache_key, $output, 15 * MINUTE_IN_SECONDS);
         return $output;
     }
     public function get_upcoming_events()

--- a/wp-content/themes/academyAfrica/posts/events.php
+++ b/wp-content/themes/academyAfrica/posts/events.php
@@ -5,6 +5,58 @@
 // Exit if accessed directly
 if (!defined('ABSPATH')) exit;
 
+/**
+ * Parse an event's stored date (optionally with time) into a timestamp, or null
+ * when the stored value is missing or unparseable. Shared by the event list and
+ * single-event views so one malformed record can't fatal on
+ * date_format(false, ...) or new DateTime() (#57, findings 17 & 39).
+ *
+ * @param mixed  $raw_date
+ * @param string $raw_time
+ * @return int|null
+ */
+function academyafrica_event_timestamp($raw_date, $raw_time = '')
+{
+    if (empty($raw_date) || !is_string($raw_date)) {
+        return null;
+    }
+    $raw_date = trim($raw_date);
+    // Treat MySQL/ACF zero-dates as missing rather than parsing them to year -1.
+    if ($raw_date === '' || strncmp($raw_date, '0000-00-00', 10) === 0) {
+        return null;
+    }
+    $value = trim($raw_date . ' ' . (is_string($raw_time) ? $raw_time : ''));
+    $ts = strtotime($value);
+
+    return false === $ts ? null : $ts;
+}
+
+/**
+ * Format an event date for display, returning $fallback for missing/invalid data.
+ *
+ * @param mixed  $raw_date
+ * @param string $format
+ * @param string $fallback
+ * @return string
+ */
+function academyafrica_format_event_date($raw_date, $format = 'd/m/Y', $fallback = '')
+{
+    $ts = academyafrica_event_timestamp($raw_date);
+
+    return null === $ts ? $fallback : date($format, $ts);
+}
+
+/**
+ * Cache-buster for the event filter options, bumped whenever an event is saved
+ * so cached filter dropdowns don't go stale (#57, finding 32).
+ *
+ * @return int
+ */
+function academyafrica_event_filters_version()
+{
+    return (int) get_option('aa_event_filters_version', 1);
+}
+
 function event_post_type()
 {
     $labels = array(
@@ -165,6 +217,9 @@ function save_details($post_id)
     if (isset($_POST["time"])) {
         update_post_meta($post_id, "time", sanitize_text_field($_POST["time"]));
     }
+
+    // Invalidate cached event filter options so new metadata shows up.
+    update_option('aa_event_filters_version', time());
 }
 
 add_action("admin_init", "admin_init");

--- a/wp-content/themes/academyAfrica/posts/events.php
+++ b/wp-content/themes/academyAfrica/posts/events.php
@@ -57,6 +57,46 @@ function academyafrica_event_filters_version()
     return (int) get_option('aa_event_filters_version', 1);
 }
 
+/**
+ * Increment the filter-cache version so cached dropdowns are recomputed.
+ * Incremented (not time()) so multiple mutations within the same second still
+ * produce distinct versions (#57 review).
+ */
+function academyafrica_bump_event_filters_version()
+{
+    update_option('aa_event_filters_version', academyafrica_event_filters_version() + 1);
+}
+
+/**
+ * Invalidate the event filter cache on any event mutation — not just editor
+ * saves. Covers create/update (editor, REST, importer), status transitions,
+ * trash/untrash, permanent deletion, and ACF field updates, so stale
+ * country/language options can't linger (#57 review).
+ *
+ * @param int          $post_id
+ * @param WP_Post|null $post
+ */
+function academyafrica_invalidate_event_filters($post_id, $post = null)
+{
+    if (wp_is_post_revision($post_id) || wp_is_post_autosave($post_id)) {
+        return;
+    }
+    $post_type = ($post instanceof WP_Post) ? $post->post_type : get_post_type($post_id);
+    if ('event' === $post_type) {
+        academyafrica_bump_event_filters_version();
+    }
+}
+add_action('save_post_event', 'academyafrica_invalidate_event_filters', 10, 2);
+add_action('before_delete_post', 'academyafrica_invalidate_event_filters', 10, 2);
+add_action('trashed_post', 'academyafrica_invalidate_event_filters', 10, 1);
+add_action('untrashed_post', 'academyafrica_invalidate_event_filters', 10, 1);
+// ACF-managed fields (countries, language, etc.) save outside save_post_event.
+add_action('acf/save_post', function ($post_id) {
+    if (is_numeric($post_id) && 'event' === get_post_type($post_id)) {
+        academyafrica_bump_event_filters_version();
+    }
+}, 20);
+
 function event_post_type()
 {
     $labels = array(
@@ -218,8 +258,8 @@ function save_details($post_id)
         update_post_meta($post_id, "time", sanitize_text_field($_POST["time"]));
     }
 
-    // Invalidate cached event filter options so new metadata shows up.
-    update_option('aa_event_filters_version', time());
+    // Filter-cache invalidation is handled independently of this metabox save by
+    // academyafrica_invalidate_event_filters() (hooked to save/delete/ACF).
 }
 
 add_action("admin_init", "admin_init");

--- a/wp-content/themes/academyAfrica/single-event.php
+++ b/wp-content/themes/academyAfrica/single-event.php
@@ -18,14 +18,13 @@ require_once __DIR__ . '/includes/utils/countries.php';
             $post_array = get_post();
             $post_id = $post_array->ID;
             $raw_date = get_post_meta($post_id, 'date', true);
-            $date = date_format(date_create($raw_date), 'Y-m-d');
-            $offset = "UTC";
             $raw_time = get_post_meta($post_id, 'time', true);
+            // Safe parsing — a missing/malformed date must not fatal the page (#57).
+            $event_ts = academyafrica_event_timestamp($raw_date, $raw_time);
+            $date = academyafrica_format_event_date($raw_date, 'Y-m-d');
 
             $registration_link = get_post_meta($post_id, 'registration_link', true);
-            $event_date_time = new DateTime($date . ' ' . $raw_time, new DateTimeZone($offset));
-            $current_date_time = new DateTime("today midnight -1 second", new DateTimeZone($offset));
-            $is_past_event = $event_date_time < $current_date_time;
+            $is_past_event = ($event_ts !== null) && $event_ts < strtotime('today midnight -1 second');
             $post_title = $post_array->post_title;
             $post_content = $post_array->post_content;
             $featured_image_url = get_the_post_thumbnail_url($post_id, 'full');
@@ -67,12 +66,13 @@ require_once __DIR__ . '/includes/utils/countries.php';
                         <img src="/wp-content/themes/academyAfrica/assets/images/icons/Type=location, Size=16, Color=Black.svg" alt="">
                         <p style="margin: 0" class="time">
                             <?php
-                            if (isset($countries)) {
+                            if (is_array($countries)) {
                                 foreach ($countries as $country) {
-                                    echo country_flag_emoji($country['value']);
+                                    if (is_array($country) && isset($country['value'])) {
+                                        echo country_flag_emoji($country['value']);
+                                    }
                                 }
                             }
-
                             ?>
                         </p>
                     </div>


### PR DESCRIPTION
## Summary

Addresses **#57** (P1) — audit findings 17, 32, and the event part of 39.

### Rendering resilience (findings 17 & 39)
- New shared helpers `academyafrica_event_timestamp()` / `academyafrica_format_event_date()` (in `posts/events.php`) parse dates via `strtotime` and return `null` / a fallback for **missing, malformed, or zero (`0000-00-00`) dates** — instead of fataling on `date_format(date_create(false))` or `new DateTime(...)`.
- `single-event.php` and the events widget both use the shared helpers, so **one malformed event can no longer break the single page or the listing**.
- Guarded optional metadata: `countries` checked with `is_array` before indexing, each entry before reading `['value']`, and `speaker` before `get_userdata`.

### Filter performance (finding 32)
- `get_filter_by()` ran an **unbounded `posts_per_page => -1` `WP_Query` per filter dimension**. Now it loads event IDs **once** and derives every meta dimension from that single set, then caches the whole result in a transient keyed by a version option bumped on event save.

## Verification
- `php -l` clean on all three files.
- Ran against the local DB:
  - `'not-a-date'` → the **old** `date_format(date_create(...))` path **threw `TypeError`**; the new helper returns the safe fallback.
  - `''`, `null`, `0000-00-00` → all normalize to the fallback (no crash).
  - Valid dates still format correctly.
  - **1 of 50 real events has an unparseable date** — previously a live crash, now rendered safely.
- Manual regression still recommended on staging: events list with each filter dimension enabled; single event with missing/blank date/time; event with no countries/speaker/organisation.

Refs #58