### PR TITLE
fix(theme): make custom cache invalidation reliable (#47)

### DIFF
--- a/wp-content/themes/academyAfrica/CACHE.md
+++ b/wp-content/themes/academyAfrica/CACHE.md
@@ -24,6 +24,12 @@ actual key = "<logical key>:v<N>"      where N = academy_africa_cache_version
 - When the backend *does* support group flushing (checked via
   `wp_cache_supports('flush_group')`), `Cache::flush()` also flushes the group
   to reclaim the stranded entries immediately.
+- `N` is stored in the **autoloaded option** `academy_africa_cache_version`, not
+  in the object cache. The fallback is only correct while the counter survives
+  and stays monotonic; a cache key could expire or be evicted under memory
+  pressure while older `:vN` data entries linger, resetting `N` to 1 and
+  resurrecting stale entries. An option never expires — only the data entries
+  carry TTLs.
 
 > Historical note: before this change the fallback bumped a version key that was
 > never part of any cache key, so on backends without `flush_group` **nothing was
@@ -51,7 +57,7 @@ Legend — **Scope**: `content` = user-agnostic, invalidated by version bump;
 | `course_status_u{uid}_c{cid}` | Per-user LearnDash course status string | 5 m | per-user | `learndash/ld30/{course,lesson,topic}.php` |
 | `course_progress_u{uid}_c{cid}` | Rendered `[learndash_course_progress]` per user | 5 m | per-user | `learndash/ld30/{course,lesson,topic,quiz}.php` |
 | `course_content_u{uid}_c{cid}` | Rendered `[course_content]` per enrolled user | 5 m | per-user | `learndash/ld30/{lesson,topic,quiz}.php` |
-| `academy_africa_cache_version` | Group version counter (internal) | 1 w | — | `Cache` helper |
+| `academy_africa_cache_version` *(autoloaded option, not a cache entry)* | Group version counter (internal) | none — durable | — | `Cache` helper |
 
 ## Invalidation triggers
 

--- a/wp-content/themes/academyAfrica/CACHE.md
+++ b/wp-content/themes/academyAfrica/CACHE.md
@@ -1,0 +1,96 @@
+# Object caching in the academyAfrica theme
+
+All custom object caches live in a single group, **`academy_africa`**, and are
+accessed exclusively through the helper in
+[`includes/utils/cache.php`](includes/utils/cache.php)
+(`AcademyAfrica\Theme\Cache\Cache`). Do **not** call `wp_cache_*()` directly for
+theme caches — always go through the helper so keys stay versioned and
+invalidation stays reliable.
+
+## Why the helper exists
+
+Invalidating "everything in a group" needs `wp_cache_flush_group()`, which many
+object-cache backends (most non-Redis-Object-Cache-Pro setups) do not support.
+To invalidate reliably on **every** backend, the helper namespaces each key with
+a version counter:
+
+```
+actual key = "<logical key>:v<N>"      where N = academy_africa_cache_version
+```
+
+- `Cache::get()/set()/delete()` transparently append `:v<N>`.
+- `Cache::flush()` bumps `N`. Every previously written key becomes unreachable,
+  so reads miss and regenerate — no group-flush support required.
+- When the backend *does* support group flushing (checked via
+  `wp_cache_supports('flush_group')`), `Cache::flush()` also flushes the group
+  to reclaim the stranded entries immediately.
+
+> Historical note: before this change the fallback bumped a version key that was
+> never part of any cache key, so on backends without `flush_group` **nothing was
+> invalidated** until TTL expiry (audit findings 27 & 28).
+
+## Cache inventory
+
+Legend — **Scope**: `content` = user-agnostic, invalidated by version bump;
+`per-user` = keyed by user, invalidated by targeted delete + version bump.
+
+| Logical key | Stores | TTL | Scope | Owner (set site) |
+|---|---|---|---|---|
+| `academy_organizations` | All published organizations (id, title, excerpt) | 1 h | content | `CoursesFunctions::getOrganizations()` |
+| `academy_all_learning_paths` | All published learning paths (id, title, excerpt) | 1 h | content | `CoursesFunctions::getAllLearningPaths()` |
+| `academy_learning_paths_{md5}` | Paginated learning paths + nested courses + count | 1 w | content | `CoursesFunctions::getLearningPaths()` |
+| `academy_instructors` | Instructor list from distinct course authors | 1 h | content | `CoursesFunctions::getAllInstructors()` |
+| `course_lessons_{course_id}` | Lesson list for a course (count + first-lesson URL) | 1 h | content | `learndash/ld30/{course,lesson,topic,quiz}.php` |
+| `course_author_data_{course_id}` | Per-course author profiles (name, avatar, socials) | 1 h | content | `learndash/ld30/course.php` |
+| `course_orgs_data_{course_id}` | Per-course organization data (title, socials, site) | 1 h | content | `learndash/ld30/course.php` |
+| `course_content_html_{course_id}` | Rendered `[course_content]` for **anonymous/unenrolled** visitors | 1 h | content | `learndash/ld30/course.php` |
+| `{course_id}_students_count` | Enrolled-student count (fallback path only) | 1 h | content | `academyafrica_count_students()` (`includes/functions/learndash.php`) |
+| `verified_users_count` | Count of verified users (hero widget) | 1 h | content | `Academy_Africa_Hero` (`includes/widgets/hero.php`) |
+| `published_courses_count` | Count of published courses (hero widget) | 1 h | content | `Academy_Africa_Hero` |
+| `published_events_count` | Count of published events (hero widget) | 1 h | content | `Academy_Africa_Hero` |
+| `course_status_u{uid}_c{cid}` | Per-user LearnDash course status string | 5 m | per-user | `learndash/ld30/{course,lesson,topic}.php` |
+| `course_progress_u{uid}_c{cid}` | Rendered `[learndash_course_progress]` per user | 5 m | per-user | `learndash/ld30/{course,lesson,topic,quiz}.php` |
+| `course_content_u{uid}_c{cid}` | Rendered `[course_content]` per enrolled user | 5 m | per-user | `learndash/ld30/{lesson,topic,quiz}.php` |
+| `academy_africa_cache_version` | Group version counter (internal) | 1 w | — | `Cache` helper |
+
+## Invalidation triggers
+
+All hooks are registered centrally in `includes/utils/cache.php`.
+
+### Content invalidation → `Cache::flush()` (bumps the version)
+
+| Hook | Fires when |
+|---|---|
+| `save_post_ac-learning-path` | A learning path is created/updated |
+| `save_post_sfwd-courses` | A course is created/updated |
+| `save_post_sfwd-lessons` | A lesson is created/updated (affects `course_lessons_*`, curricula) |
+| `save_post_sfwd-topic` / `save_post_sfwd-quiz` | A topic/quiz is created/updated |
+| `save_post_ac-organization` | An organization is edited |
+| `save_post_event` | An event is created/updated (hero events count) |
+| `delete_post` | Any of the above post types is deleted |
+| `profile_update` | A user profile changes (author/instructor data) |
+
+Autosaves and revisions are skipped. Invalidation is intentionally **global**:
+one counter covers the whole group, so any content save clears every content
+cache. Writes are rare (admin edits), so the re-warm cost is negligible and
+correctness is guaranteed.
+
+### Per-user invalidation → targeted `Cache::delete()`
+
+| Hook | Clears |
+|---|---|
+| `learndash_update_course_access` (enrollment / access change) | `course_status_u{uid}_c{cid}`, `course_progress_…`, `course_content_…`, `{cid}_students_count` |
+| `learndash_lesson_completed` / `…_topic_completed` / `…_quiz_completed` | `course_status_…`, `course_progress_…`, `course_content_…` for that user+course |
+| `added_user_meta` / `updated_user_meta` / `deleted_user_meta` (key `is_verified`) | `verified_users_count` |
+
+## Tests
+
+`tests/cache-invalidation-test.php` stubs the WordPress cache API and verifies
+versioned keys, the group-flush path, the **no-group-flush fallback** (the
+original bug), and every targeted-delete hook. Run:
+
+```bash
+php wp-content/themes/academyAfrica/tests/cache-invalidation-test.php
+```
+
+Exit code `0` = all pass.

--- a/wp-content/themes/academyAfrica/functions.php
+++ b/wp-content/themes/academyAfrica/functions.php
@@ -712,6 +712,9 @@ if (!function_exists('get_coauthors')) {
     }
 }
 
+// Central object-cache helper + invalidation hooks (save/delete/enrollment/completion).
+require_once __DIR__ . '/includes/utils/cache.php';
+
 $inc_dir = __DIR__ . '/includes/functions/';
 foreach (['learndash', 'login', 'password_reset', 'polylang-strings', 'register'] as $_inc) {
     require_once $inc_dir . $_inc . '.php';
@@ -738,21 +741,8 @@ add_filter(
  * certificate content and switches to "freeserif" — a Unicode font bundled with
  * TCPDF that supports Arabic, Ethiopic, Hebrew, Cyrillic, CJK, and many others.
  */
-/**
- * Invalidate the per-user [course_content] sidebar cache when a user
- * completes a lesson, topic, or quiz so their progress marks stay current.
- */
-foreach (['learndash_lesson_completed', 'learndash_topic_completed', 'learndash_quiz_completed'] as $_ld_hook) {
-    add_action($_ld_hook, function (array $data) {
-        $course_id = $data['course']->ID ?? ($data['course_id'] ?? 0);
-        $user_id   = $data['user']->ID ?? ($data['user_id'] ?? 0);
-        if ($course_id && $user_id) {
-            wp_cache_delete('course_content_u' . $user_id . '_c' . $course_id, 'academy_africa');
-            wp_cache_delete('course_status_u' . $user_id . '_c' . $course_id, 'academy_africa');
-            wp_cache_delete('course_progress_u' . $user_id . '_c' . $course_id, 'academy_africa');
-        }
-    });
-}
+// Per-user progress cache invalidation on lesson/topic/quiz completion is
+// registered centrally in includes/utils/cache.php (loaded above).
 
 add_filter('learndash_certificate_content', function ($cert_content, $_cert_id) {
     // Unicode ranges for scripts that standard TCPDF fonts cannot render:

--- a/wp-content/themes/academyAfrica/includes/functions/learndash.php
+++ b/wp-content/themes/academyAfrica/includes/functions/learndash.php
@@ -11,7 +11,7 @@ function academyafrica_count_students($post_id)
     }
 
     $cache_key = absint($post_id) . '_students_count';
-    $count = wp_cache_get($cache_key, 'academy_africa');
+    $count = \AcademyAfrica\Theme\Cache\Cache::get($cache_key);
 
     if (false !== $count) {
         return $count;
@@ -34,7 +34,7 @@ function academyafrica_count_students($post_id)
     );
     $count = (int) $wpdb->get_var($query);
 
-    wp_cache_set($cache_key, $count, 'academy_africa', HOUR_IN_SECONDS);
+    \AcademyAfrica\Theme\Cache\Cache::set($cache_key, $count, HOUR_IN_SECONDS);
 
     return $count;
 }

--- a/wp-content/themes/academyAfrica/includes/utils/cache.php
+++ b/wp-content/themes/academyAfrica/includes/utils/cache.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace AcademyAfrica\Theme\Cache;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Central object-cache helper for the academyAfrica theme.
+ *
+ * All custom caches live in the single group `academy_africa`. Reliable
+ * invalidation is hard because many object-cache backends do not implement
+ * group flushing (`wp_cache_flush_group()` / `WP_Object_Cache::flush_group()`).
+ * When that is unavailable we cannot delete "everything in a group" directly.
+ *
+ * The fix is a *versioned key namespace*: every cache key is suffixed with a
+ * monotonically increasing version counter (`Cache::key()`), and invalidation
+ * bumps that counter (`Cache::flush()`). After a bump, every previously written
+ * key is unreachable — reads miss and regenerate — regardless of whether the
+ * backend supports group flushing. Where the backend *does* support it, we also
+ * flush the group to reclaim the orphaned entries immediately.
+ *
+ * See CACHE.md (in the theme root) for the full key/owner/TTL/invalidation map.
+ */
+class Cache
+{
+    /** Cache group shared by every custom cache in the theme. */
+    public const GROUP = 'academy_africa';
+
+    /** Key holding the group's namespace version counter. */
+    public const VERSION_KEY = 'academy_africa_cache_version';
+
+    /**
+     * Current namespace version for the group. Seeded to 1 on first read so
+     * keys never carry `:v0`, which reads as ambiguous.
+     */
+    public static function version(): int
+    {
+        $version = wp_cache_get(self::VERSION_KEY, self::GROUP);
+        if (false === $version) {
+            $version = 1;
+            wp_cache_set(self::VERSION_KEY, $version, self::GROUP, WEEK_IN_SECONDS);
+        }
+        return (int) $version;
+    }
+
+    /**
+     * Build a version-namespaced cache key. A `Cache::flush()` bumps the
+     * version, so the returned string changes and every prior key is stranded.
+     */
+    public static function key(string $key): string
+    {
+        return $key . ':v' . self::version();
+    }
+
+    /** Read a value written through {@see self::set()}. */
+    public static function get(string $key)
+    {
+        return wp_cache_get(self::key($key), self::GROUP);
+    }
+
+    /** Write a value under the versioned key. TTL defaults to non-expiring. */
+    public static function set(string $key, $data, int $ttl = 0): bool
+    {
+        return wp_cache_set(self::key($key), $data, self::GROUP, $ttl);
+    }
+
+    /** Delete a single versioned key (used for targeted per-user invalidation). */
+    public static function delete(string $key): bool
+    {
+        return wp_cache_delete(self::key($key), self::GROUP);
+    }
+
+    /**
+     * Whether the active object cache backend can flush an entire group.
+     * Prefers the canonical `wp_cache_supports()` (WP 6.1+) and falls back to
+     * a plain function-existence check on older cores.
+     */
+    public static function supports_group_flush(): bool
+    {
+        if (function_exists('wp_cache_supports')) {
+            return wp_cache_supports('flush_group');
+        }
+        return function_exists('wp_cache_flush_group');
+    }
+
+    /**
+     * Invalidate every user-agnostic cache in the group.
+     *
+     * Always bumps the namespace version (the universally reliable path). When
+     * the backend supports group flushing we flush first to reclaim memory, then
+     * bump — after a real flush the version key is gone, so the bump restarts the
+     * namespace cleanly with no risk of colliding with stranded entries.
+     */
+    public static function flush(): void
+    {
+        if (self::supports_group_flush()) {
+            wp_cache_flush_group(self::GROUP);
+        }
+        $next = ((int) wp_cache_get(self::VERSION_KEY, self::GROUP)) + 1;
+        wp_cache_set(self::VERSION_KEY, $next, self::GROUP, WEEK_IN_SECONDS);
+
+        do_action('qm/debug', 'Cache: flushed academy_africa group (version {version})', [
+            'version' => $next,
+        ]);
+    }
+}
+
+/*
+ * -----------------------------------------------------------------------------
+ * Invalidation hooks
+ * -----------------------------------------------------------------------------
+ * Registered once, on include. Two kinds of invalidation:
+ *   1. Content changes  -> Cache::flush() (bumps the group version).
+ *   2. Per-user changes -> targeted Cache::delete() of the affected keys.
+ */
+
+if (!defined('ACADEMY_AFRICA_CACHE_HOOKS_REGISTERED')) {
+    define('ACADEMY_AFRICA_CACHE_HOOKS_REGISTERED', true);
+
+    /**
+     * Post types whose creation/update/deletion can change any user-agnostic
+     * cache (course listings, learning paths, curricula, org/author data,
+     * published counts).
+     */
+    $academy_africa_cache_post_types = [
+        'ac-learning-path',
+        'sfwd-courses',
+        'sfwd-lessons',
+        'sfwd-topic',
+        'sfwd-quiz',
+        'ac-organization',
+        'event',
+    ];
+
+    // Flush on save of any relevant post type. save_post_{type} keeps this
+    // cheap — the callback only fires for the types we care about.
+    foreach ($academy_africa_cache_post_types as $academy_africa_cache_type) {
+        add_action('save_post_' . $academy_africa_cache_type, static function ($post_id): void {
+            // Skip autosaves/revisions — they never change published content.
+            if (wp_is_post_autosave($post_id) || wp_is_post_revision($post_id)) {
+                return;
+            }
+            Cache::flush();
+        });
+    }
+
+    // Flush on deletion of any relevant post type (delete_post is generic).
+    add_action('delete_post', static function ($post_id) use ($academy_africa_cache_post_types): void {
+        if (in_array(get_post_type($post_id), $academy_africa_cache_post_types, true)) {
+            Cache::flush();
+        }
+    });
+
+    // Author/instructor data (academy_instructors, course_author_data_*)
+    // is built from user profile + ACF user meta.
+    add_action('profile_update', static function (): void {
+        Cache::flush();
+    });
+
+    // Verified-user hero counter: clear when the is_verified meta changes.
+    $academy_africa_verified_meta = static function ($meta_id, $object_id, $meta_key): void {
+        if ('is_verified' === $meta_key) {
+            Cache::delete('verified_users_count');
+        }
+    };
+    add_action('added_user_meta', $academy_africa_verified_meta, 10, 3);
+    add_action('updated_user_meta', $academy_africa_verified_meta, 10, 3);
+    add_action('deleted_user_meta', $academy_africa_verified_meta, 10, 3);
+
+    /**
+     * Enrollment / access changes. Fires when a user gains or loses access to a
+     * course (manual enrollment, group enrollment, purchase, expiry). Clears the
+     * affected user's per-course status/progress/curriculum caches plus the
+     * course's student-count cache.
+     *
+     * @param int  $user_id
+     * @param int  $course_id
+     */
+    add_action('learndash_update_course_access', static function ($user_id, $course_id): void {
+        $user_id   = (int) $user_id;
+        $course_id = (int) $course_id;
+        if (!$user_id || !$course_id) {
+            return;
+        }
+        Cache::delete('course_status_u' . $user_id . '_c' . $course_id);
+        Cache::delete('course_progress_u' . $user_id . '_c' . $course_id);
+        Cache::delete('course_content_u' . $user_id . '_c' . $course_id);
+        Cache::delete($course_id . '_students_count');
+    }, 10, 2);
+
+    /**
+     * Lesson / topic / quiz completion. Clears the completing user's per-course
+     * status, progress bar, and rendered curriculum so their progress marks
+     * update on the next request.
+     */
+    foreach (['learndash_lesson_completed', 'learndash_topic_completed', 'learndash_quiz_completed'] as $academy_africa_completion_hook) {
+        add_action($academy_africa_completion_hook, static function ($data): void {
+            $course_id = 0;
+            $user_id   = 0;
+            if (is_array($data)) {
+                $course_id = isset($data['course']->ID) ? (int) $data['course']->ID : (int) ($data['course_id'] ?? 0);
+                $user_id   = isset($data['user']->ID) ? (int) $data['user']->ID : (int) ($data['user_id'] ?? 0);
+            }
+            if ($course_id && $user_id) {
+                Cache::delete('course_content_u' . $user_id . '_c' . $course_id);
+                Cache::delete('course_status_u' . $user_id . '_c' . $course_id);
+                Cache::delete('course_progress_u' . $user_id . '_c' . $course_id);
+            }
+        });
+    }
+}

--- a/wp-content/themes/academyAfrica/includes/utils/cache.php
+++ b/wp-content/themes/academyAfrica/includes/utils/cache.php
@@ -28,21 +28,32 @@ class Cache
     /** Cache group shared by every custom cache in the theme. */
     public const GROUP = 'academy_africa';
 
-    /** Key holding the group's namespace version counter. */
-    public const VERSION_KEY = 'academy_africa_cache_version';
+    /**
+     * Option holding the group's namespace version counter.
+     *
+     * Stored as an autoloaded option (durable, in the DB) rather than an
+     * object-cache key: on a persistent backend without group flushing, the
+     * version-bump fallback is only correct while the counter survives and
+     * stays monotonic. A cache key can expire or be evicted under memory
+     * pressure while older `:vN` data entries linger — the counter would then
+     * reset to 1 and reads could hit entries that were meant to be invalidated.
+     * An option never expires; only the data entries carry TTLs.
+     */
+    public const VERSION_OPTION = 'academy_africa_cache_version';
 
     /**
      * Current namespace version for the group. Seeded to 1 on first read so
-     * keys never carry `:v0`, which reads as ambiguous.
+     * keys never carry `:v0`, which reads as ambiguous. Backed by an autoloaded
+     * option, so the read is served from the alloptions cache (no per-call query).
      */
     public static function version(): int
     {
-        $version = wp_cache_get(self::VERSION_KEY, self::GROUP);
-        if (false === $version) {
+        $version = (int) get_option(self::VERSION_OPTION, 0);
+        if ($version < 1) {
             $version = 1;
-            wp_cache_set(self::VERSION_KEY, $version, self::GROUP, WEEK_IN_SECONDS);
+            update_option(self::VERSION_OPTION, $version, true);
         }
-        return (int) $version;
+        return $version;
     }
 
     /**
@@ -88,18 +99,18 @@ class Cache
     /**
      * Invalidate every user-agnostic cache in the group.
      *
-     * Always bumps the namespace version (the universally reliable path). When
-     * the backend supports group flushing we flush first to reclaim memory, then
-     * bump — after a real flush the version key is gone, so the bump restarts the
-     * namespace cleanly with no risk of colliding with stranded entries.
+     * Monotonically bumps the durable namespace version (the universally
+     * reliable path — every prior `:vN` key becomes unreachable). When the
+     * backend supports group flushing we also flush the group first to reclaim
+     * the stranded entries immediately.
      */
     public static function flush(): void
     {
         if (self::supports_group_flush()) {
             wp_cache_flush_group(self::GROUP);
         }
-        $next = ((int) wp_cache_get(self::VERSION_KEY, self::GROUP)) + 1;
-        wp_cache_set(self::VERSION_KEY, $next, self::GROUP, WEEK_IN_SECONDS);
+        $next = self::version() + 1;
+        update_option(self::VERSION_OPTION, $next, true);
 
         do_action('qm/debug', 'Cache: flushed academy_africa group (version {version})', [
             'version' => $next,

--- a/wp-content/themes/academyAfrica/includes/utils/courses.php
+++ b/wp-content/themes/academyAfrica/includes/utils/courses.php
@@ -2,13 +2,16 @@
 
 namespace AcademyAfrica\Theme\Courses;
 
+require_once __DIR__ . '/cache.php';
+
+use AcademyAfrica\Theme\Cache\Cache;
 
 class CoursesFunctions
 {
 
     public static function getOrganizations()
     {
-        $cached = wp_cache_get('academy_organizations', 'academy_africa');
+        $cached = Cache::get('academy_organizations');
         if (false !== $cached) {
             return $cached;
         }
@@ -28,13 +31,13 @@ class CoursesFunctions
                 'excerpt' => $organization_post->post_excerpt
             );
         }
-        wp_cache_set('academy_organizations', $organizations, 'academy_africa', HOUR_IN_SECONDS);
+        Cache::set('academy_organizations', $organizations, HOUR_IN_SECONDS);
         return $organizations;
     }
 
     public static function getAllLearningPaths()
     {
-        $cached = wp_cache_get('academy_all_learning_paths', 'academy_africa');
+        $cached = Cache::get('academy_all_learning_paths');
         if (false !== $cached) {
             return $cached;
         }
@@ -54,7 +57,7 @@ class CoursesFunctions
                 'excerpt' => $learning_path_post->post_excerpt
             );
         }
-        wp_cache_set('academy_all_learning_paths', $learning_paths, 'academy_africa', HOUR_IN_SECONDS);
+        Cache::set('academy_all_learning_paths', $learning_paths, HOUR_IN_SECONDS);
         return $learning_paths;
     }
 
@@ -74,7 +77,7 @@ class CoursesFunctions
             'order'    => $order,
         ]));
 
-        $cached = wp_cache_get($cache_key, 'academy_africa');
+        $cached = Cache::get($cache_key);
         if (false !== $cached) {
             do_action('qm/debug', 'getLearningPaths: cache hit (per_page={per_page})', [
                 'per_page' => $attr['per_page'],
@@ -143,14 +146,14 @@ class CoursesFunctions
             'per_page'       => $attr['per_page'],
         );
 
-        wp_cache_set($cache_key, $result, 'academy_africa', WEEK_IN_SECONDS);
+        Cache::set($cache_key, $result, WEEK_IN_SECONDS);
 
         return $result;
     }
 
     public static function getAllInstructors()
     {
-        $cached = wp_cache_get('academy_instructors', 'academy_africa');
+        $cached = Cache::get('academy_instructors');
         if (false !== $cached) {
             return $cached;
         }
@@ -172,7 +175,7 @@ class CoursesFunctions
                 );
             }
         }
-        wp_cache_set('academy_instructors', $instructors, 'academy_africa', HOUR_IN_SECONDS);
+        Cache::set('academy_instructors', $instructors, HOUR_IN_SECONDS);
         do_action('qm/stop', 'getAllInstructors');
         do_action('qm/debug', 'getAllInstructors: loaded {count} instructors', ['count' => count($instructors)]);
         return $instructors;
@@ -481,30 +484,15 @@ class CoursesFunctions
     }
 
     /**
-     * Flush all learning-path cache entries.
-     * Called whenever a learning path or course is saved/deleted so stale
-     * data never shows. wp_cache_flush_group() is used when available
-     * (Redis Object Cache Pro); otherwise falls back to a version bump
-     * that effectively invalidates all keys in the group.
+     * Flush all learning-path (and other user-agnostic) cache entries.
+     *
+     * Thin wrapper around {@see Cache::flush()}, kept for backward
+     * compatibility with any callers referencing this method. The actual
+     * invalidation hooks (save/delete/enrollment/completion) are registered
+     * centrally in includes/utils/cache.php.
      */
-    public static function flush_learning_path_cache(): void {
-        if (function_exists('wp_cache_flush_group')) {
-            wp_cache_flush_group('academy_africa');
-        } else {
-            // Bump a version key — all getLearningPaths keys become stale
-            $version = (int) wp_cache_get('academy_lp_cache_version', 'academy_africa');
-            wp_cache_set('academy_lp_cache_version', $version + 1, 'academy_africa', WEEK_IN_SECONDS);
-        }
-        do_action('qm/debug', 'CoursesFunctions: learning path cache flushed');
+    public static function flush_learning_path_cache(): void
+    {
+        Cache::flush();
     }
 }
-
-// Invalidate learning path cache whenever a learning path or course is saved/deleted
-add_action('save_post_ac-learning-path', ['AcademyAfrica\Theme\Courses\CoursesFunctions', 'flush_learning_path_cache']);
-add_action('delete_post',                function (int $post_id): void {
-    if (get_post_type($post_id) === 'ac-learning-path') {
-        AcademyAfrica\Theme\Courses\CoursesFunctions::flush_learning_path_cache();
-    }
-});
-// Also flush when a course that belongs to a learning path is updated
-add_action('save_post_sfwd-courses',     ['AcademyAfrica\Theme\Courses\CoursesFunctions', 'flush_learning_path_cache']);

--- a/wp-content/themes/academyAfrica/includes/widgets/hero.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/hero.php
@@ -34,7 +34,7 @@ class Academy_Africa_Hero extends \Elementor\Widget_Base
 
     public function get_verified_users_count()
     {
-        $count = wp_cache_get('verified_users_count', 'academy_africa');
+        $count = \AcademyAfrica\Theme\Cache\Cache::get('verified_users_count');
         if (false !== $count) {
             return $count;
         }
@@ -42,29 +42,29 @@ class Academy_Africa_Hero extends \Elementor\Widget_Base
         $count = (int) $wpdb->get_var(
             "SELECT COUNT(*) FROM {$wpdb->usermeta} WHERE meta_key = 'is_verified' AND meta_value = '1'"
         );
-        wp_cache_set('verified_users_count', $count, 'academy_africa', HOUR_IN_SECONDS);
+        \AcademyAfrica\Theme\Cache\Cache::set('verified_users_count', $count, HOUR_IN_SECONDS);
         return $count;
     }
 
     public function get_courses_count()
     {
-        $count = wp_cache_get('published_courses_count', 'academy_africa');
+        $count = \AcademyAfrica\Theme\Cache\Cache::get('published_courses_count');
         if (false !== $count) {
             return $count;
         }
         $count = (int) wp_count_posts('sfwd-courses')->publish;
-        wp_cache_set('published_courses_count', $count, 'academy_africa', HOUR_IN_SECONDS);
+        \AcademyAfrica\Theme\Cache\Cache::set('published_courses_count', $count, HOUR_IN_SECONDS);
         return $count;
     }
 
     public function get_events_count()
     {
-        $count = wp_cache_get('published_events_count', 'academy_africa');
+        $count = \AcademyAfrica\Theme\Cache\Cache::get('published_events_count');
         if (false !== $count) {
             return $count;
         }
         $count = (int) wp_count_posts('event')->publish;
-        wp_cache_set('published_events_count', $count, 'academy_africa', HOUR_IN_SECONDS);
+        \AcademyAfrica\Theme\Cache\Cache::set('published_events_count', $count, HOUR_IN_SECONDS);
         return $count;
     }
     protected function register_controls()

--- a/wp-content/themes/academyAfrica/learndash/ld30/course.php
+++ b/wp-content/themes/academyAfrica/learndash/ld30/course.php
@@ -20,10 +20,10 @@ $organizations     = get_field('organization', $course_id) ?: [];
 $related_courses   = get_field('related_courses', $course_id) ?: [];
 $short_description = get_field('short_description', $course_id) ?: '';
 $cs_cache_key  = 'course_status_u' . $user_id . '_c' . $course_id;
-$course_status = wp_cache_get($cs_cache_key, 'academy_africa');
+$course_status = \AcademyAfrica\Theme\Cache\Cache::get($cs_cache_key);
 if (false === $course_status) {
     $course_status = learndash_course_status($course_id);
-    wp_cache_set($cs_cache_key, $course_status, 'academy_africa', 5 * MINUTE_IN_SECONDS);
+    \AcademyAfrica\Theme\Cache\Cache::set($cs_cache_key, $course_status, 5 * MINUTE_IN_SECONDS);
 }
 $post_data         = get_post($course_id);
 if (!$post_data) {
@@ -38,7 +38,7 @@ $course_language = function_exists('pll_get_post_language') ? pll_get_post_langu
 // ------------------------------------------------------------------
 do_action('qm/start', 'course:fetch_lessons');
 
-$lessons = wp_cache_get('course_lessons_' . $course_id, 'academy_africa');
+$lessons = \AcademyAfrica\Theme\Cache\Cache::get('course_lessons_' . $course_id);
 if (false === $lessons) {
     $lessons = learndash_get_course_lessons_list($course_id, 0);
     if (empty($lessons)) {
@@ -56,7 +56,7 @@ if (false === $lessons) {
         ]);
     }
     $lessons = $lessons ?: [];
-    wp_cache_set('course_lessons_' . $course_id, $lessons, 'academy_africa', HOUR_IN_SECONDS);
+    \AcademyAfrica\Theme\Cache\Cache::set('course_lessons_' . $course_id, $lessons, HOUR_IN_SECONDS);
     if (empty($lessons)) {
         do_action('qm/warning', 'course.php: no lessons found for course_id={id}', ['id' => $course_id]);
     }
@@ -92,7 +92,7 @@ $course_pathways = array_filter($pathways['learning_paths'], function ($pathway)
 // Instructor data — cached per course; multiple get_field() +
 // get_user_meta() calls per author add up fast with co-authors
 // ------------------------------------------------------------------
-$authors_data = wp_cache_get('course_author_data_' . $course_id, 'academy_africa');
+$authors_data = \AcademyAfrica\Theme\Cache\Cache::get('course_author_data_' . $course_id);
 if (false === $authors_data) {
     $raw_authors = get_coauthors();
     if (empty($raw_authors)) {
@@ -125,13 +125,13 @@ if (false === $authors_data) {
             'website'     => get_the_author_meta('website',   $author->ID) ?: ($author->website ?? ''),
         ];
     }
-    wp_cache_set('course_author_data_' . $course_id, $authors_data, 'academy_africa', HOUR_IN_SECONDS);
+    \AcademyAfrica\Theme\Cache\Cache::set('course_author_data_' . $course_id, $authors_data, HOUR_IN_SECONDS);
 }
 
 // ------------------------------------------------------------------
 // Organization data — cached per course; 6× get_field() per org
 // ------------------------------------------------------------------
-$orgs_data = wp_cache_get('course_orgs_data_' . $course_id, 'academy_africa');
+$orgs_data = \AcademyAfrica\Theme\Cache\Cache::get('course_orgs_data_' . $course_id);
 if (false === $orgs_data) {
     $orgs_data = [];
     foreach ($organizations as $organization) {
@@ -147,7 +147,7 @@ if (false === $orgs_data) {
             'website'   => get_field('website',   $organization->ID),
         ];
     }
-    wp_cache_set('course_orgs_data_' . $course_id, $orgs_data, 'academy_africa', HOUR_IN_SECONDS);
+    \AcademyAfrica\Theme\Cache\Cache::set('course_orgs_data_' . $course_id, $orgs_data, HOUR_IN_SECONDS);
 }
 
 ?>
@@ -205,10 +205,10 @@ if ($course_status == "Completed" && $is_cert) {
                 <div class='progress'>
                     <?php
                     $cp_cache_key = 'course_progress_u' . $user_id . '_c' . $course_id;
-                    $cp_output    = wp_cache_get($cp_cache_key, 'academy_africa');
+                    $cp_output    = \AcademyAfrica\Theme\Cache\Cache::get($cp_cache_key);
                     if (false === $cp_output) {
                         $cp_output = do_shortcode('[learndash_course_progress]');
-                        wp_cache_set($cp_cache_key, $cp_output, 'academy_africa', 5 * MINUTE_IN_SECONDS);
+                        \AcademyAfrica\Theme\Cache\Cache::set($cp_cache_key, $cp_output, 5 * MINUTE_IN_SECONDS);
                     }
                     echo $cp_output;
                     ?>
@@ -279,10 +279,10 @@ if ($course_status == "Completed" && $is_cert) {
                     do_action('qm/start', 'course:course_content_shortcode');
                     if (!$is_enrolled) {
                         $cc_cache_key = 'course_content_html_' . $course_id;
-                        $cc_output = wp_cache_get($cc_cache_key, 'academy_africa');
+                        $cc_output = \AcademyAfrica\Theme\Cache\Cache::get($cc_cache_key);
                         if (false === $cc_output) {
                             $cc_output = do_shortcode('[course_content course_id="' . $course_id . '"]');
-                            wp_cache_set($cc_cache_key, $cc_output, 'academy_africa', HOUR_IN_SECONDS);
+                            \AcademyAfrica\Theme\Cache\Cache::set($cc_cache_key, $cc_output, HOUR_IN_SECONDS);
                         }
                         echo $cc_output;
                     } else {

--- a/wp-content/themes/academyAfrica/learndash/ld30/lesson.php
+++ b/wp-content/themes/academyAfrica/learndash/ld30/lesson.php
@@ -20,10 +20,10 @@ if (!$course_id) {
 }
 
 $cs_cache_key  = 'course_status_u' . $user_id . '_c' . $course_id;
-$course_status = wp_cache_get($cs_cache_key, 'academy_africa');
+$course_status = \AcademyAfrica\Theme\Cache\Cache::get($cs_cache_key);
 if (false === $course_status) {
     $course_status = learndash_course_status($course_id);
-    wp_cache_set($cs_cache_key, $course_status, 'academy_africa', 5 * MINUTE_IN_SECONDS);
+    \AcademyAfrica\Theme\Cache\Cache::set($cs_cache_key, $course_status, 5 * MINUTE_IN_SECONDS);
 }
 $course_url    = get_permalink($course_id);
 $course        = get_post($course_id);
@@ -32,11 +32,11 @@ if (!$course) {
 }
 
 // Lesson list — shared cache with course.php (user-agnostic, just count + structure)
-$lessons = wp_cache_get('course_lessons_' . $course_id, 'academy_africa');
+$lessons = \AcademyAfrica\Theme\Cache\Cache::get('course_lessons_' . $course_id);
 if (false === $lessons) {
     do_action('qm/start', 'lesson:fetch_lessons');
     $lessons = learndash_get_course_lessons_list($course_id, 0) ?: [];
-    wp_cache_set('course_lessons_' . $course_id, $lessons, 'academy_africa', HOUR_IN_SECONDS);
+    \AcademyAfrica\Theme\Cache\Cache::set('course_lessons_' . $course_id, $lessons, HOUR_IN_SECONDS);
     do_action('qm/stop', 'lesson:fetch_lessons');
     do_action('qm/debug', 'lesson:fetch_lessons: DB fetch {count} lessons for course {id}', [
         'count' => count($lessons),
@@ -79,10 +79,10 @@ do_action('qm/stop', 'lesson:init');
                         </div>
                         <?php
                         $cp_cache_key = 'course_progress_u' . $user_id . '_c' . $course_id;
-                        $cp_output    = wp_cache_get($cp_cache_key, 'academy_africa');
+                        $cp_output    = \AcademyAfrica\Theme\Cache\Cache::get($cp_cache_key);
                         if (false === $cp_output) {
                             $cp_output = do_shortcode('[learndash_course_progress]');
-                            wp_cache_set($cp_cache_key, $cp_output, 'academy_africa', 5 * MINUTE_IN_SECONDS);
+                            \AcademyAfrica\Theme\Cache\Cache::set($cp_cache_key, $cp_output, 5 * MINUTE_IN_SECONDS);
                         }
                         echo $cp_output;
                         ?>
@@ -94,10 +94,10 @@ do_action('qm/stop', 'lesson:init');
                     // AJAX so page reloads don't need a fresh render on every request.
                     do_action('qm/start', 'lesson:course_content_shortcode');
                     $cc_cache_key = 'course_content_u' . $user_id . '_c' . $course_id;
-                    $cc_output    = wp_cache_get($cc_cache_key, 'academy_africa');
+                    $cc_output    = \AcademyAfrica\Theme\Cache\Cache::get($cc_cache_key);
                     if (false === $cc_output) {
                         $cc_output = do_shortcode('[course_content course_id="' . $course_id . '"]');
-                        wp_cache_set($cc_cache_key, $cc_output, 'academy_africa', 5 * MINUTE_IN_SECONDS);
+                        \AcademyAfrica\Theme\Cache\Cache::set($cc_cache_key, $cc_output, 5 * MINUTE_IN_SECONDS);
                     }
                     echo $cc_output;
                     do_action('qm/stop', 'lesson:course_content_shortcode');

--- a/wp-content/themes/academyAfrica/learndash/ld30/quiz.php
+++ b/wp-content/themes/academyAfrica/learndash/ld30/quiz.php
@@ -21,11 +21,11 @@ if (!$course) {
 }
 
 // Lesson list — shared cache with course.php (user-agnostic, just count + structure)
-$lessons = wp_cache_get('course_lessons_' . $course_id, 'academy_africa');
+$lessons = \AcademyAfrica\Theme\Cache\Cache::get('course_lessons_' . $course_id);
 if (false === $lessons) {
     do_action('qm/start', 'quiz:fetch_lessons');
     $lessons = learndash_get_course_lessons_list($course_id, 0) ?: [];
-    wp_cache_set('course_lessons_' . $course_id, $lessons, 'academy_africa', HOUR_IN_SECONDS);
+    \AcademyAfrica\Theme\Cache\Cache::set('course_lessons_' . $course_id, $lessons, HOUR_IN_SECONDS);
     do_action('qm/stop', 'quiz:fetch_lessons');
     do_action('qm/debug', 'quiz:fetch_lessons: DB fetch {count} lessons for course {id}', [
         'count' => count($lessons),
@@ -67,10 +67,10 @@ do_action('qm/stop', 'quiz:init');
                             </div>
                             <?php
                             $cp_cache_key = 'course_progress_u' . $user_id . '_c' . $course_id;
-                            $cp_output    = wp_cache_get($cp_cache_key, 'academy_africa');
+                            $cp_output    = \AcademyAfrica\Theme\Cache\Cache::get($cp_cache_key);
                             if (false === $cp_output) {
                                 $cp_output = do_shortcode('[learndash_course_progress]');
-                                wp_cache_set($cp_cache_key, $cp_output, 'academy_africa', 5 * MINUTE_IN_SECONDS);
+                                \AcademyAfrica\Theme\Cache\Cache::set($cp_cache_key, $cp_output, 5 * MINUTE_IN_SECONDS);
                             }
                             echo $cp_output;
                             ?>
@@ -82,10 +82,10 @@ do_action('qm/stop', 'quiz:init');
                         // AJAX so page reloads don't need a fresh render on every request.
                         do_action('qm/start', 'quiz:course_content_shortcode');
                         $cc_cache_key = 'course_content_u' . $user_id . '_c' . $course_id;
-                        $cc_output    = wp_cache_get($cc_cache_key, 'academy_africa');
+                        $cc_output    = \AcademyAfrica\Theme\Cache\Cache::get($cc_cache_key);
                         if (false === $cc_output) {
                             $cc_output = do_shortcode('[course_content course_id="' . $course_id . '"]');
-                            wp_cache_set($cc_cache_key, $cc_output, 'academy_africa', 5 * MINUTE_IN_SECONDS);
+                            \AcademyAfrica\Theme\Cache\Cache::set($cc_cache_key, $cc_output, 5 * MINUTE_IN_SECONDS);
                         }
                         echo $cc_output;
                         do_action('qm/stop', 'quiz:course_content_shortcode');

--- a/wp-content/themes/academyAfrica/learndash/ld30/topic.php
+++ b/wp-content/themes/academyAfrica/learndash/ld30/topic.php
@@ -15,10 +15,10 @@ if (!$course_id) {
 }
 
 $cs_cache_key  = 'course_status_u' . $user_id . '_c' . $course_id;
-$course_status = wp_cache_get($cs_cache_key, 'academy_africa');
+$course_status = \AcademyAfrica\Theme\Cache\Cache::get($cs_cache_key);
 if (false === $course_status) {
     $course_status = learndash_course_status($course_id);
-    wp_cache_set($cs_cache_key, $course_status, 'academy_africa', 5 * MINUTE_IN_SECONDS);
+    \AcademyAfrica\Theme\Cache\Cache::set($cs_cache_key, $course_status, 5 * MINUTE_IN_SECONDS);
 }
 $course_url    = get_permalink($course_id);
 $course        = get_post($course_id);
@@ -27,11 +27,11 @@ if (!$course) {
 }
 
 // Lesson list — shared cache with course.php (user-agnostic, just count + structure)
-$lessons = wp_cache_get('course_lessons_' . $course_id, 'academy_africa');
+$lessons = \AcademyAfrica\Theme\Cache\Cache::get('course_lessons_' . $course_id);
 if (false === $lessons) {
     do_action('qm/start', 'topic:fetch_lessons');
     $lessons = learndash_get_course_lessons_list($course_id, 0) ?: [];
-    wp_cache_set('course_lessons_' . $course_id, $lessons, 'academy_africa', HOUR_IN_SECONDS);
+    \AcademyAfrica\Theme\Cache\Cache::set('course_lessons_' . $course_id, $lessons, HOUR_IN_SECONDS);
     do_action('qm/stop', 'topic:fetch_lessons');
     do_action('qm/debug', 'topic:fetch_lessons: DB fetch {count} lessons for course {id}', [
         'count' => count($lessons),
@@ -73,10 +73,10 @@ do_action('qm/stop', 'topic:init');
                         </div>
                         <?php
                         $cp_cache_key = 'course_progress_u' . $user_id . '_c' . $course_id;
-                        $cp_output    = wp_cache_get($cp_cache_key, 'academy_africa');
+                        $cp_output    = \AcademyAfrica\Theme\Cache\Cache::get($cp_cache_key);
                         if (false === $cp_output) {
                             $cp_output = do_shortcode('[learndash_course_progress]');
-                            wp_cache_set($cp_cache_key, $cp_output, 'academy_africa', 5 * MINUTE_IN_SECONDS);
+                            \AcademyAfrica\Theme\Cache\Cache::set($cp_cache_key, $cp_output, 5 * MINUTE_IN_SECONDS);
                         }
                         echo $cp_output;
                         ?>
@@ -88,10 +88,10 @@ do_action('qm/stop', 'topic:init');
                     // AJAX so page reloads don't need a fresh render on every request.
                     do_action('qm/start', 'topic:course_content_shortcode');
                     $cc_cache_key = 'course_content_u' . $user_id . '_c' . $course_id;
-                    $cc_output    = wp_cache_get($cc_cache_key, 'academy_africa');
+                    $cc_output    = \AcademyAfrica\Theme\Cache\Cache::get($cc_cache_key);
                     if (false === $cc_output) {
                         $cc_output = do_shortcode('[course_content course_id="' . $course_id . '"]');
-                        wp_cache_set($cc_cache_key, $cc_output, 'academy_africa', 5 * MINUTE_IN_SECONDS);
+                        \AcademyAfrica\Theme\Cache\Cache::set($cc_cache_key, $cc_output, 5 * MINUTE_IN_SECONDS);
                     }
                     echo $cc_output;
                     do_action('qm/stop', 'topic:course_content_shortcode');

--- a/wp-content/themes/academyAfrica/tests/cache-invalidation-test.php
+++ b/wp-content/themes/academyAfrica/tests/cache-invalidation-test.php
@@ -23,6 +23,8 @@ define('WEEK_IN_SECONDS', 604800);
 // it behaves like a persistent backend (Redis/Memcached) — exactly the setup
 // where the old version-bump fallback silently failed.
 $GLOBALS['__store'] = [];
+// Durable options store (survives object-cache flush/eviction).
+$GLOBALS['__options'] = [];
 // Toggle: does the simulated backend support wp_cache_flush_group()?
 $GLOBALS['__supports_flush_group'] = false;
 // Captured hook callbacks so we can fire enrollment/completion handlers.
@@ -89,6 +91,19 @@ function get_post_type($id)
     return $GLOBALS['__post_types'][$id] ?? 'post';
 }
 
+// Durable options store — the namespace version now lives here, not in the
+// object cache, so it survives cache eviction/flush (the reviewed fix).
+function get_option($name, $default = false)
+{
+    return array_key_exists($name, $GLOBALS['__options']) ? $GLOBALS['__options'][$name] : $default;
+}
+
+function update_option($name, $value, $autoload = null)
+{
+    $GLOBALS['__options'][$name] = $value;
+    return true;
+}
+
 // ---------------------------------------------------------------------------
 // Load the code under test
 // ---------------------------------------------------------------------------
@@ -118,6 +133,7 @@ function check($label, $cond)
 function reset_cache($supports_flush_group)
 {
     $GLOBALS['__store'] = [];
+    $GLOBALS['__options'] = [];
     $GLOBALS['__supports_flush_group'] = $supports_flush_group;
 }
 
@@ -157,8 +173,25 @@ Cache::set('academy_organizations', ['org'], HOUR_IN_SECONDS);
 check('value readable before flush', Cache::get('academy_organizations') === ['org']);
 Cache::flush();
 check('value is a MISS after flush', Cache::get('academy_organizations') === false);
-// Group was physically flushed, so no orphaned entries linger.
-check('group physically emptied (no stranded keys)', count($GLOBALS['__store']) <= 1);
+// Group was physically flushed and the version lives in an option, not the
+// group — so the object-cache store is completely empty after a flush.
+check('group physically emptied (no stranded keys)', count($GLOBALS['__store']) === 0);
+
+// --- 3b. Version counter survives object-cache eviction (reviewed fix) ------
+// Simulate a persistent backend that evicts the whole object cache while
+// older :vN data entries would otherwise linger. Because the version is a
+// durable option, it must NOT reset to 1 and stale reads must stay misses.
+echo "\n[version survives cache eviction]\n";
+reset_cache(false);
+Cache::set('academy_organizations', ['stale'], HOUR_IN_SECONDS);
+Cache::flush();                       // version -> 2
+$v_after_flush = Cache::version();
+$GLOBALS['__store'] = [];              // object cache evicted/cleared entirely
+check('version persists across eviction (no reset to 1)', Cache::version() === $v_after_flush);
+check('version is still >= 2 after eviction', Cache::version() >= 2);
+// A value written before the eviction at :v1 must never be resurrected.
+$GLOBALS['__store']["academy_africa\0academy_organizations:v1"] = ['zombie'];
+check('stranded :v1 entry is not read after bump+eviction', Cache::get('academy_organizations') === false);
 
 // --- 4. Targeted per-user delete (completion / enrollment) ------------------
 echo "\n[targeted per-user delete]\n";

--- a/wp-content/themes/academyAfrica/tests/cache-invalidation-test.php
+++ b/wp-content/themes/academyAfrica/tests/cache-invalidation-test.php
@@ -1,0 +1,231 @@
+<?php
+
+/**
+ * Self-contained tests for the academyAfrica cache-invalidation helper.
+ *
+ * There is no WordPress/PHPUnit harness in this repo, so this file stubs the
+ * handful of WordPress functions the helper touches and drives Cache directly.
+ *
+ * Run:  php wp-content/themes/academyAfrica/tests/cache-invalidation-test.php
+ * Exit code 0 = all passed, 1 = a failure (suitable for CI).
+ */
+
+// ---------------------------------------------------------------------------
+// Minimal WordPress environment stubs
+// ---------------------------------------------------------------------------
+
+define('ABSPATH', __DIR__);
+define('MINUTE_IN_SECONDS', 60);
+define('HOUR_IN_SECONDS', 3600);
+define('WEEK_IN_SECONDS', 604800);
+
+// In-memory object cache: keys are "group\0key". Persists across a flush() so
+// it behaves like a persistent backend (Redis/Memcached) — exactly the setup
+// where the old version-bump fallback silently failed.
+$GLOBALS['__store'] = [];
+// Toggle: does the simulated backend support wp_cache_flush_group()?
+$GLOBALS['__supports_flush_group'] = false;
+// Captured hook callbacks so we can fire enrollment/completion handlers.
+$GLOBALS['__hooks'] = [];
+
+function __ck($key, $group)
+{
+    return $group . "\0" . $key;
+}
+
+function wp_cache_get($key, $group = '')
+{
+    $ck = __ck($key, $group);
+    return array_key_exists($ck, $GLOBALS['__store']) ? $GLOBALS['__store'][$ck] : false;
+}
+
+function wp_cache_set($key, $data, $group = '', $ttl = 0)
+{
+    $GLOBALS['__store'][__ck($key, $group)] = $data;
+    return true;
+}
+
+function wp_cache_delete($key, $group = '')
+{
+    unset($GLOBALS['__store'][__ck($key, $group)]);
+    return true;
+}
+
+function wp_cache_supports($feature)
+{
+    if ('flush_group' === $feature) {
+        return (bool) $GLOBALS['__supports_flush_group'];
+    }
+    return false;
+}
+
+function wp_cache_flush_group($group)
+{
+    foreach (array_keys($GLOBALS['__store']) as $ck) {
+        if (strpos($ck, $group . "\0") === 0) {
+            unset($GLOBALS['__store'][$ck]);
+        }
+    }
+    return true;
+}
+
+function add_action($hook, $cb, $priority = 10, $args = 1)
+{
+    $GLOBALS['__hooks'][$hook][] = $cb;
+}
+
+function do_action() {}
+
+function wp_is_post_autosave($id)
+{
+    return false;
+}
+function wp_is_post_revision($id)
+{
+    return false;
+}
+function get_post_type($id)
+{
+    return $GLOBALS['__post_types'][$id] ?? 'post';
+}
+
+// ---------------------------------------------------------------------------
+// Load the code under test
+// ---------------------------------------------------------------------------
+
+require_once __DIR__ . '/../includes/utils/cache.php';
+
+use AcademyAfrica\Theme\Cache\Cache;
+
+// ---------------------------------------------------------------------------
+// Tiny assertion framework
+// ---------------------------------------------------------------------------
+
+$GLOBALS['__pass'] = 0;
+$GLOBALS['__fail'] = 0;
+
+function check($label, $cond)
+{
+    if ($cond) {
+        $GLOBALS['__pass']++;
+        echo "  \033[32mPASS\033[0m  $label\n";
+    } else {
+        $GLOBALS['__fail']++;
+        echo "  \033[31mFAIL\033[0m  $label\n";
+    }
+}
+
+function reset_cache($supports_flush_group)
+{
+    $GLOBALS['__store'] = [];
+    $GLOBALS['__supports_flush_group'] = $supports_flush_group;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+echo "\nCache invalidation tests\n========================\n";
+
+// --- 1. Versioned keys embed the group version -----------------------------
+echo "\n[versioned keys]\n";
+reset_cache(false);
+$k1 = Cache::key('academy_learning_paths_abc');
+check('key contains a version suffix', (bool) preg_match('/:v\d+$/', $k1));
+check('same key is stable within a version', $k1 === Cache::key('academy_learning_paths_abc'));
+
+// --- 2. FALLBACK PATH: flush works WITHOUT group-flush support --------------
+// This is the regression from findings 27/28: previously the version bump was
+// never part of the key, so on a backend without flush_group the value stayed.
+echo "\n[fallback: no wp_cache flush_group support]\n";
+reset_cache(false);
+check('backend reports no group-flush support', Cache::supports_group_flush() === false);
+Cache::set('academy_learning_paths_abc', ['stale'], WEEK_IN_SECONDS);
+check('value readable before flush', Cache::get('academy_learning_paths_abc') === ['stale']);
+$before = Cache::version();
+Cache::flush();
+check('version bumped by flush', Cache::version() === $before + 1);
+check('stale value is now a MISS after flush', Cache::get('academy_learning_paths_abc') === false);
+Cache::set('academy_learning_paths_abc', ['fresh'], WEEK_IN_SECONDS);
+check('fresh value readable after re-set', Cache::get('academy_learning_paths_abc') === ['fresh']);
+
+// --- 3. flush WITH group-flush support (Redis Object Cache Pro) -------------
+echo "\n[with wp_cache flush_group support]\n";
+reset_cache(true);
+check('backend reports group-flush support', Cache::supports_group_flush() === true);
+Cache::set('academy_organizations', ['org'], HOUR_IN_SECONDS);
+check('value readable before flush', Cache::get('academy_organizations') === ['org']);
+Cache::flush();
+check('value is a MISS after flush', Cache::get('academy_organizations') === false);
+// Group was physically flushed, so no orphaned entries linger.
+check('group physically emptied (no stranded keys)', count($GLOBALS['__store']) <= 1);
+
+// --- 4. Targeted per-user delete (completion / enrollment) ------------------
+echo "\n[targeted per-user delete]\n";
+reset_cache(false);
+Cache::set('course_status_u7_c42', 'In Progress', 300);
+Cache::set('course_progress_u7_c42', '<div>50%</div>', 300);
+Cache::set('course_content_u7_c42', '<ul>…</ul>', 300);
+Cache::set('course_status_u9_c42', 'Not Started', 300); // another user, must survive
+Cache::delete('course_status_u7_c42');
+Cache::delete('course_progress_u7_c42');
+Cache::delete('course_content_u7_c42');
+check('user 7 status deleted', Cache::get('course_status_u7_c42') === false);
+check('user 7 progress deleted', Cache::get('course_progress_u7_c42') === false);
+check('user 7 content deleted', Cache::get('course_content_u7_c42') === false);
+check('user 9 status untouched', Cache::get('course_status_u9_c42') === 'Not Started');
+
+// --- 5. Enrollment hook clears the right keys -------------------------------
+echo "\n[learndash_update_course_access hook]\n";
+reset_cache(false);
+Cache::set('course_status_u7_c42', 'In Progress', 300);
+Cache::set('course_progress_u7_c42', 'x', 300);
+Cache::set('course_content_u7_c42', 'y', 300);
+Cache::set('42_students_count', 123, HOUR_IN_SECONDS);
+$enroll_cbs = $GLOBALS['__hooks']['learndash_update_course_access'] ?? [];
+check('enrollment hook is registered', count($enroll_cbs) === 1);
+foreach ($enroll_cbs as $cb) {
+    $cb(7, 42);
+}
+check('enrollment clears user status', Cache::get('course_status_u7_c42') === false);
+check('enrollment clears user progress', Cache::get('course_progress_u7_c42') === false);
+check('enrollment clears user content', Cache::get('course_content_u7_c42') === false);
+check('enrollment clears students count', Cache::get('42_students_count') === false);
+
+// --- 6. Completion hook clears the right keys -------------------------------
+echo "\n[learndash_*_completed hooks]\n";
+reset_cache(false);
+Cache::set('course_status_u7_c42', 'In Progress', 300);
+Cache::set('course_progress_u7_c42', 'x', 300);
+Cache::set('course_content_u7_c42', 'y', 300);
+$lesson_cbs = $GLOBALS['__hooks']['learndash_lesson_completed'] ?? [];
+check('lesson-completed hook is registered', count($lesson_cbs) === 1);
+foreach ($lesson_cbs as $cb) {
+    $cb(['user_id' => 7, 'course_id' => 42]);
+}
+check('completion clears user status', Cache::get('course_status_u7_c42') === false);
+check('completion clears user progress', Cache::get('course_progress_u7_c42') === false);
+check('completion clears user content', Cache::get('course_content_u7_c42') === false);
+
+// --- 7. Verified-user counter meta hook -------------------------------------
+echo "\n[is_verified meta hook]\n";
+reset_cache(false);
+Cache::set('verified_users_count', 500, HOUR_IN_SECONDS);
+$meta_cbs = $GLOBALS['__hooks']['updated_user_meta'] ?? [];
+check('user-meta hook is registered', count($meta_cbs) === 1);
+foreach ($meta_cbs as $cb) {
+    $cb(1, 55, 'unrelated_meta'); // should NOT clear
+}
+check('unrelated meta leaves counter intact', Cache::get('verified_users_count') === 500);
+foreach ($meta_cbs as $cb) {
+    $cb(1, 55, 'is_verified'); // should clear
+}
+check('is_verified change clears counter', Cache::get('verified_users_count') === false);
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+echo "\n========================\n";
+echo "Passed: {$GLOBALS['__pass']}   Failed: {$GLOBALS['__fail']}\n\n";
+exit($GLOBALS['__fail'] === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #47

## Problem

Custom object caches in the theme all live in the `academy_africa` group and relied on `wp_cache_flush_group()` for invalidation. On backends that don't support group flushing, the fallback bumped a version counter (`academy_lp_cache_version`) that **was never part of any cache key** — so nothing was actually invalidated until TTL expiry (audit findings 27 & 28). Several caches (organizations, student count, hero counters, `course_content_html_*`) had no working invalidation trigger at all.

## Changes

- **New central helper** `AcademyAfrica\Theme\Cache\Cache` (`includes/utils/cache.php`) with a **versioned key namespace**: every key is suffixed `:v{N}` and `flush()` bumps `N`, so invalidation is reliable on every backend — not just Redis Object Cache Pro. Uses the canonical `wp_cache_supports('flush_group')` check and still flushes the group when supported to reclaim memory.
- **Routed all cache keys** (courses utils, the four LearnDash `ld30` templates, hero widget, student count) through the helper. No direct `wp_cache_*` calls remain outside the helper.
- **Wired the missing invalidation hooks** (centralized in the helper):
  - Content flush on save/delete for `sfwd-lessons`, `sfwd-topic`, `sfwd-quiz`, `ac-organization`, `event` (in addition to the existing learning-path/course hooks); `profile_update` for author/instructor data. Autosaves/revisions skipped.
  - **Enrollment** (`learndash_update_course_access`) → clears the user's status/progress/content caches + the course's student count. Previously missing entirely.
  - Completion hooks moved here and updated to delete the *versioned* keys.
  - `is_verified` user-meta change → clears the verified-users hero counter.
- **Documentation**: `CACHE.md` maps every key, owner, TTL and invalidation trigger.
- **Tests**: `tests/cache-invalidation-test.php` stubs the WP cache API and verifies versioned keys, the group-flush path, the no-group-flush fallback (the original bug), and every targeted-delete hook — 27 assertions, runnable with plain `php` (no PHPUnit in the repo).

## Done when (from the issue)

- ✅ Content and progression changes appear immediately with persistent object caching enabled
- ✅ Unsupported group flushing uses a working versioned fallback
- ✅ Cache keys, owners, TTLs, and invalidation hooks are documented and tested

## Test plan

```bash
php wp-content/themes/academyAfrica/tests/cache-invalidation-test.php   # 27/27 pass
```

Manual: enroll/unenroll a user (progress bar + student count update immediately); edit a course/lesson/organization with a persistent object cache enabled (change reflects immediately).