### PR TITLE
fix(theme): correct course metadata, filtering, and sorting (#49)

### DIFF
--- a/wp-content/themes/academyAfrica/includes/utils/courses.php
+++ b/wp-content/themes/academyAfrica/includes/utils/courses.php
@@ -263,9 +263,7 @@ class CoursesFunctions
             }
         }
 
-        $meta_query = array(
-            'relation' => 'OR',
-        );
+        $meta_query = array();
         $organization = !empty($atts['organization']) ? $atts['organization'] : [];
         if (!empty($organization)) {
             $orgs = self::getOrganizations();
@@ -283,6 +281,11 @@ class CoursesFunctions
                 );
                 array_push($meta_query, $org_q);
             }
+        }
+        // Match any of the selected organizations (OR within the group). Only
+        // add the relation when there are multiple clauses to combine.
+        if (count($meta_query) > 1) {
+            $meta_query['relation'] = 'OR';
         }
 
         $language = !empty($atts['language']) ? $atts['language'] : [];
@@ -303,11 +306,19 @@ class CoursesFunctions
                 }
             }
 
-            $post__in = $courses;
+            // A learning-path filter is active. If it resolves to no courses
+            // (empty or unknown path), return zero results. WP_Query ignores an
+            // empty post__in array — which would otherwise show ALL courses —
+            // so use a non-existent ID to force an empty result set.
+            $post__in = !empty($courses) ? $courses : [0];
         }
 
-
-        $tax_query['relation'] = 'OR';
+        // Combine multiple taxonomy clauses with OR (a course matches if it has
+        // any of the selected terms). Different filter groups (taxonomy, meta,
+        // author, learning path) are still AND-ed together by WP_Query.
+        if (count($tax_query) > 1) {
+            $tax_query['relation'] = 'OR';
+        }
 
         $author_query = [];
         $instructors = !empty($atts['instructor']) ? $atts['instructor'] : [];
@@ -318,14 +329,20 @@ class CoursesFunctions
             }
         }
 
+        // Allowlist orderby/order so an unexpected value can never reach the
+        // SQL ORDER BY clause; unknown values fall back to a safe default.
+        $allowed_orderby = ['ID', 'title', 'date', 'name', 'menu_order', 'author', 'modified', 'rand'];
+        $orderby = in_array($atts['orderby'], $allowed_orderby, true) ? $atts['orderby'] : 'date';
+        $order   = strtoupper((string) $atts['order']) === 'ASC' ? 'ASC' : 'DESC';
+
         $query_args = apply_filters('academy-africa_course_grid_query_args', [
             'post_type' => sanitize_text_field($atts['post_type']),
             'posts_per_page' => intval($atts['per_page']),
             'paged' => intval($atts['paged']),
             's' => sanitize_text_field($atts['search']),
             'post_status' => 'publish',
-            'orderby' => sanitize_text_field($atts['orderby']),
-            'order' => sanitize_text_field($atts['order']),
+            'orderby' => $orderby,
+            'order' => $order,
             'tax_query' => $tax_query,
             'post__in' => $post__in,
             'author__in' => $author_query,
@@ -395,6 +412,8 @@ class CoursesFunctions
         $price = '';
         $price_type = '';
         $price_text = '';
+        $students_count = 0;
+        $price_args = [];
         if ($post->post_type == 'sfwd-courses') {
             // $course_options = get_post_meta($post->ID, '_sfwd-courses', true);
             $students_count = academyafrica_count_students($post->ID);
@@ -433,7 +452,7 @@ class CoursesFunctions
 
         $user_object = get_user_by('ID', $post->post_author);
         $author = apply_filters('academy-africa_course_grid_author', [
-            'name' => $user_object->display_name,
+            'name' => $user_object ? $user_object->display_name : '',
             'avatar' => get_avatar_url($post->post_author),
         ], $post->ID, $post->post_author);
         $course_link = get_permalink($post->ID);

--- a/wp-content/themes/academyAfrica/includes/widgets/all_courses.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/all_courses.php
@@ -219,11 +219,14 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
 
         $sort_by = $settings['sort_by_text'];
         $sort = $this->get_query_param('sort');
-        if (!empty($sort)) {
-            $sort = $sort[0];
+        $sort = !empty($sort) ? $sort[0] : '';
+        // Only honour a sort value that is one of the offered options; anything
+        // else (absent, tampered, or renamed) falls back to the safe default.
+        if ($sort !== '' && isset($sort_options[$sort])) {
             $order_by = $sort_options[$sort]["orderby"];
             $order = $sort_options[$sort]["order"];
         } else {
+            $sort = '';
             $order_by = "date";
             $order = "DESC";
         }
@@ -375,17 +378,21 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
                             foreach ($courses as $course) {
                                 $course_title = get_the_title($course);
                                 $authors = get_coauthors($course->ID);
-                                $first_name = get_the_author_meta('first_name', $authors[0]->ID);
-                                $last_name = get_the_author_meta('last_name', $authors[0]->ID);
-                                $course_author = (!empty($first_name) && !empty($last_name)) ? $first_name . ' ' . $last_name : $authors[0]->display_name;
+                                if (!empty($authors)) {
+                                    $first_name = get_the_author_meta('first_name', $authors[0]->ID);
+                                    $last_name = get_the_author_meta('last_name', $authors[0]->ID);
+                                    $course_author = (!empty($first_name) && !empty($last_name)) ? $first_name . ' ' . $last_name : $authors[0]->display_name;
 
-                                if (count($authors) > 1) {
-                                    $course_author .= ' + ' . (count($authors) - 1) . ' more';
+                                    if (count($authors) > 1) {
+                                        $course_author .= ' + ' . (count($authors) - 1) . ' more';
+                                    }
+                                } else {
+                                    $course_author = '';
                                 }
                                 $course_thumbnail = get_the_post_thumbnail_url($course, 'full');
                                 $course_link = get_permalink($course);
                                 $course_meta = get_post_meta($course->ID, 'sfwd-courses', true);
-                                $course_price = is_array($course_meta) ? $course_meta['sfwd-courses_course_price'] : 0;
+                                $course_price = is_array($course_meta) ? ($course_meta['sfwd-courses_course_price'] ?? 0) : 0;
                                 $course_price = empty($course_price) ? "Free" : $course_price;
 
                                 $course_attrs = CoursesFunctions::get_post_attr($course, $atts);

--- a/wp-content/themes/academyAfrica/includes/widgets/featured_courses.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/featured_courses.php
@@ -226,7 +226,7 @@ class Academy_Africa_Featured_Courses extends \Elementor\Widget_Base
         if (!empty($courses)) {
             $first_course = $courses[0];
             $course_name = get_the_title($first_course);
-            $course_meta = get_post_meta($first_course, 'sfwd-courses', true);
+            $course_meta = get_post_meta($first_course->ID, 'sfwd-courses', true);
             if (is_array($course_meta) && !empty($course_meta['sfwd-courses_course_completion_date'])) {
             $course_completion_date = $course_meta['sfwd-courses_course_completion_date'];
             }
@@ -261,8 +261,8 @@ class Academy_Africa_Featured_Courses extends \Elementor\Widget_Base
                             $course_author = get_the_author_meta('display_name', $course->post_author);
                             $course_thumbnail = get_the_post_thumbnail_url($course);
                             $course_link = get_permalink($course);
-                            $course_meta = get_post_meta($course, 'sfwd-courses', true);
-                            $course_price = is_array($course_meta) ? $course_meta['sfwd-courses_course_price'] : 0;
+                            $course_meta = get_post_meta($course->ID, 'sfwd-courses', true);
+                            $course_price = is_array($course_meta) ? ($course_meta['sfwd-courses_course_price'] ?? 0) : 0;
                             $course_price = empty($course_price) ? "Free" : $course_price;
 
                             $course_attrs = CoursesFunctions::get_post_attr($course, $atts);

--- a/wp-content/themes/academyAfrica/includes/widgets/my_courses.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/my_courses.php
@@ -81,7 +81,8 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
         $current_page = $this->get_query_param("page");
         $current_page = !empty($current_page) ? $current_page[0] : 1;
         $user_id = get_current_user_id();
-        $order_by = $this->sort_params()[$sort];
+        $sort_params = $this->sort_params();
+        $order_by = $sort_params[$sort] ?? $sort_params['date-desc'];
         $args = array(
             'post_types' => 'sfwd-courses',
             'activity_types' => 'course',
@@ -106,7 +107,8 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
         $current_page = $this->get_query_param("courses_page");
         $current_page = !empty($current_page) ? $current_page[0] : 1;
         $course_ids = learndash_user_get_enrolled_courses(get_current_user_id());
-        $order_by = $this->sort_params()[$sort];
+        $sort_params = $this->sort_params();
+        $order_by = $sort_params[$sort] ?? $sort_params['date-desc'];
         $args = array(
             'post_types' => 'sfwd-courses',
             'activity_types' => 'course',
@@ -146,6 +148,10 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
         $my_courses_pagination = $enrolled_courses["pager"] ?? [];
         $sort = $this->get_query_param('sort');
         $sort_by = "Sort By";
+        // Only date ordering is offered here: My Courses lists come from
+        // learndash_reports_get_activity(), which sorts by activity timestamps
+        // (see sort_params()) and cannot order by course title. Offering a
+        // name sort would produce an unsupported ordering.
         $sort_options = [
             "date-desc" => [
                 "orderby" => "date",
@@ -156,16 +162,6 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                 "orderby" => "date",
                 "order" => "ASC",
                 "name" => "Oldest"
-            ],
-            "name-asc" => [
-                "orderby" => "title",
-                "order" => "ASC",
-                "name" => "Name (A-Z)"
-            ],
-            "name-desc" => [
-                "orderby" => "title",
-                "order" => "DESC",
-                "name" => "Name (Z-A)"
             ]
         ];
         $user = array(
@@ -253,13 +249,17 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                                 $course = get_post($course_id);
                                 $title = get_the_title($course);
                                 $authors = get_coauthors($course->ID);
-                                $first_name = get_the_author_meta('first_name', $authors[0]->ID);
-                                $last_name = get_the_author_meta('last_name', $authors[0]->ID);
-                                $provider = (!empty($first_name) && !empty($last_name)) ? $first_name . ' ' . $last_name : $authors[0]->display_name;
-                                $course_link = get_permalink($course);
-                                if (count($authors) > 1) {
-                                    $provider .= ' + ' . (count($authors) - 1) . ' more';
+                                if (!empty($authors)) {
+                                    $first_name = get_the_author_meta('first_name', $authors[0]->ID);
+                                    $last_name = get_the_author_meta('last_name', $authors[0]->ID);
+                                    $provider = (!empty($first_name) && !empty($last_name)) ? $first_name . ' ' . $last_name : $authors[0]->display_name;
+                                    if (count($authors) > 1) {
+                                        $provider .= ' + ' . (count($authors) - 1) . ' more';
+                                    }
+                                } else {
+                                    $provider = '';
                                 }
+                                $course_link = get_permalink($course);
                                 $course_thumbnail = get_the_post_thumbnail_url($course);
                                 $mooc_logo = get_stylesheet_directory_uri() . '/assets/images/mooc-logo-blue.svg';
                                 $image = $course_thumbnail ? $course_thumbnail : $mooc_logo;
@@ -374,11 +374,15 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                                     $cert_post = get_post($certificate_id);
                                     $title = get_the_title($course);
                                     $authors = get_coauthors($course_id);
-                                    $first_name = get_the_author_meta('first_name', $authors[0]->ID);
-                                    $last_name = get_the_author_meta('last_name', $authors[0]->ID);
-                                    $course_author = (!empty($first_name) && !empty($last_name)) ? $first_name . ' ' . $last_name : $authors[0]->display_name;
-                                    if (count($authors) > 1) {
-                                        $course_author .= ' + ' . (count($authors) - 1) . ' more';
+                                    if (!empty($authors)) {
+                                        $first_name = get_the_author_meta('first_name', $authors[0]->ID);
+                                        $last_name = get_the_author_meta('last_name', $authors[0]->ID);
+                                        $course_author = (!empty($first_name) && !empty($last_name)) ? $first_name . ' ' . $last_name : $authors[0]->display_name;
+                                        if (count($authors) > 1) {
+                                            $course_author .= ' + ' . (count($authors) - 1) . ' more';
+                                        }
+                                    } else {
+                                        $course_author = '';
                                     }
                                     $course_link = add_query_arg("certificate", 1, get_permalink($course_id));
                                     $progress = learndash_user_get_course_progress(get_current_user_id(), $course_id, 'legacy');
@@ -393,8 +397,12 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                             ?>
 
                                     <div class="cert-pdf" id="<?php echo $course_id ?>">
-                                        <?php $cert_content = $this->replace_course_info($cert_post->post_content, $course_id) ?>
-                                        <?php echo do_shortcode($cert_content) ?>
+                                        <?php
+                                        if ($cert_post instanceof WP_Post) {
+                                            $cert_content = $this->replace_course_info($cert_post->post_content, $course_id);
+                                            echo do_shortcode($cert_content);
+                                        }
+                                        ?>
                                     </div>
                                     <div>
                                         <div class="card">


### PR DESCRIPTION
Closes #49

## Problem

Course widgets and the shared course query contained unsafe data assumptions and query-parameter edge cases that produced incorrect results or PHP warnings (audit findings 18–23). All affected code is in the theme; the `plugins/academy-africa` widgets are static mock/placeholder versions and were not touched.

## Changes

**Featured prices come from the correct course** — `includes/widgets/featured_courses.php` passed a `WP_Post` object to `get_post_meta()` (both the completion-date lookup and the per-course price), so meta never resolved and prices always fell back to "Free". Now passes `$course->ID`, with a null-coalescing guard on the price key.

**Every displayed sort option works / unknown values use a safe default**
- `includes/widgets/all_courses.php`: the `sort` query param was used as an unchecked array index into `$sort_options`, throwing undefined-array-key warnings and feeding `null` orderby/order into the query. It's now allowlisted against the offered options and normalised to a string (which also fixes the "selected option" highlighting); anything unknown falls back to date-desc.
- `includes/widgets/my_courses.php`: the dropdown offered name sorts that `learndash_reports_get_activity()` can't perform. Trimmed the options to the supported date orderings and gave the `sort_params()` lookups a safe default.
- `includes/utils/courses.php` `build_query()`: `orderby`/`order` are allowlisted before reaching the SQL ORDER BY.

**Empty pathways return no results** — `build_query()` set `post__in = []` when a selected learning path resolved to zero courses; WP_Query ignores an empty `post__in` array and returned **all** courses. Now uses `[0]` to force an empty result set. (No path selected still correctly applies no restriction.)

**Orphaned course data does not generate warnings** — added guards for a missing author (`get_user_by()` → `false`), empty `get_coauthors()` results (all three widget loops), a missing `sfwd-courses_course_price` meta key, and a missing certificate post; initialised `$students_count`/`$price_args` in `get_post_attr()`.

**Filter AND/OR semantics** — confirmed and made explicit: OR within a facet (multiple organizations / taxonomy terms), AND across facets (organization vs instructor vs learning path). Stopped setting a dangling `relation` on empty tax/meta groups. No change to matching behaviour.

## Done when (from the issue)

- ✅ Featured prices come from the correct course
- ✅ Every displayed sort option works and unknown values use a safe default
- ✅ Empty pathways return no results
- ✅ Orphaned course data does not generate warnings

## Test plan

- Course grid: pick each sort option and confirm ordering; hit a URL with a bogus `?sort=` value and confirm it defaults cleanly with no warnings.
- Select a learning-path filter whose path has no courses → expect zero results (not all courses).
- Featured Courses widget: confirm the real course price renders (not always "Free").
- View a course whose author account was deleted, and a course with no co-authors → no PHP warnings.