### PR TITLE
fix(theme): harden shared template data and post-type configuration (#50)

### DIFF
--- a/wp-content/themes/academyAfrica/edit-profile.php
+++ b/wp-content/themes/academyAfrica/edit-profile.php
@@ -93,7 +93,7 @@ if (is_user_logged_in()) {
     $website = get_user_meta($user_id, 'website', true);
     $company = get_user_meta($user_id, 'company', true);
     $user_meta = get_user_meta($user_id);
-    $description = $user_meta['description'][0];
+    $description = $user_meta['description'][0] ?? '';
     $prefix = get_user_meta($user_id, 'prefix', true);
     $phone = get_user_meta($user_id, 'phone', true);
     $user_networks = explode(",", get_user_meta($user_id, 'networks', true));

--- a/wp-content/themes/academyAfrica/functions.php
+++ b/wp-content/themes/academyAfrica/functions.php
@@ -160,14 +160,31 @@ function academyafrica_posttype_maintenance()
     $legacy_ids = $wpdb->get_col(
         $wpdb->prepare("SELECT ID FROM {$wpdb->posts} WHERE post_type = %s", 'Footer')
     );
+    // Bail without recording completion on a DB error, so a later request retries
+    // instead of skipping the migration forever and leaving the footer broken.
+    if ('' !== $wpdb->last_error) {
+        return;
+    }
+
     if (!empty($legacy_ids)) {
-        $wpdb->query("UPDATE {$wpdb->posts} SET post_type = 'footer' WHERE post_type = 'Footer'");
+        $updated = $wpdb->query(
+            $wpdb->prepare(
+                "UPDATE {$wpdb->posts} SET post_type = %s WHERE post_type = %s",
+                'footer',
+                'Footer'
+            )
+        );
+        if (false === $updated || '' !== $wpdb->last_error) {
+            return; // leave the flag unset so the migration is retried
+        }
         foreach ($legacy_ids as $legacy_id) {
             clean_post_cache((int) $legacy_id);
         }
     }
 
     flush_rewrite_rules(false);
+
+    // Only now that the migration + flush have succeeded do we record completion.
     update_option('academyafrica_posttype_maint_version', $version);
 }
 add_action('init', 'academyafrica_posttype_maintenance', 20);

--- a/wp-content/themes/academyAfrica/functions.php
+++ b/wp-content/themes/academyAfrica/functions.php
@@ -99,7 +99,7 @@ function create_organization_post_type()
             ),
             'public' => true,
             'has_archive' => false,
-            "heirarchical" => true,
+            'hierarchical' => true,
             'rewrite' => array('slug' => 'academy-africa-organizations'),
             'show_in_rest' => true,
             'supports' => array('title', 'thumbnail', 'editor', 'excerpt', 'custom-fields', 'revisions', 'page-attributes')
@@ -119,7 +119,7 @@ function create_learning_path_post_type()
             ),
             'public' => true,
             'has_archive' => false,
-            "heirarchical" => true,
+            'hierarchical' => true,
             'rewrite' => array('slug' => 'learning-pathways'),
             'show_in_rest' => true,
             'supports' => array('title', 'thumbnail', 'editor', 'excerpt', 'custom-fields', 'revisions', 'page-attributes')
@@ -138,6 +138,39 @@ require_once __DIR__ . '/posts/footer.php';
 add_action('init', 'event_post_type');
 add_action('init', 'create_networks_post_type');
 add_action('init', 'create_footer_post_type');
+
+/**
+ * One-time post-type maintenance, run after the post types are registered.
+ *
+ * Guarded by an option so it runs once per version bump:
+ *  - Migrates legacy footer posts stored under the old capitalized `Footer`
+ *    key to the lowercase `footer` key (post-type keys are case-sensitive, so
+ *    otherwise the footer query would never find them).
+ *  - Flushes rewrite rules so the corrected `hierarchical` config and the
+ *    footer slug take effect without a manual Permalinks re-save.
+ */
+function academyafrica_posttype_maintenance()
+{
+    $version = '2024-07-footer-hierarchy';
+    if (get_option('academyafrica_posttype_maint_version') === $version) {
+        return;
+    }
+
+    global $wpdb;
+    $legacy_ids = $wpdb->get_col(
+        $wpdb->prepare("SELECT ID FROM {$wpdb->posts} WHERE post_type = %s", 'Footer')
+    );
+    if (!empty($legacy_ids)) {
+        $wpdb->query("UPDATE {$wpdb->posts} SET post_type = 'footer' WHERE post_type = 'Footer'");
+        foreach ($legacy_ids as $legacy_id) {
+            clean_post_cache((int) $legacy_id);
+        }
+    }
+
+    flush_rewrite_rules(false);
+    update_option('academyafrica_posttype_maint_version', $version);
+}
+add_action('init', 'academyafrica_posttype_maintenance', 20);
 
 function redirect_to_custom_profile_edit()
 {

--- a/wp-content/themes/academyAfrica/includes/widgets/connect_and_collaborate.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/connect_and_collaborate.php
@@ -96,7 +96,7 @@ class Academy_Africa_Connect_and_Collaborate extends \Elementor\Widget_Base
         $become_a_member_text = $settings["become_a_member_text"];
         $join_us_on_slack = $settings["join_us_on_slack"];
         $title = $settings["title"];
-        $join_us_url = $settings["join_us_url"]["url"];
+        $join_us_url = $settings["join_us_url"]["url"] ?? '';
         ?>
         <div class="connect">
             <div class="title-wrapper">

--- a/wp-content/themes/academyAfrica/includes/widgets/header.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/header.php
@@ -88,7 +88,7 @@ class Academy_Africa_Header_Section extends \Elementor\Widget_Base
         $settings = $this->get_settings_for_display();
         $title = $settings['title'];
         $headline = $settings['headline'];
-        $header_image = $settings['header_image']['url'];
+        $header_image = $settings['header_image']['url'] ?? '';
         $social_media_links = [
             [
                 'link' => [

--- a/wp-content/themes/academyAfrica/includes/widgets/hero.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/hero.php
@@ -142,7 +142,7 @@ class Academy_Africa_Hero extends \Elementor\Widget_Base
         $settings = $this->get_settings_for_display();
         $title = $settings['title'];
         $sign_up_label = $settings['sign_up_label'];
-        $sign_up_url = $settings['sign_up_link']['url'];
+        $sign_up_url = $settings['sign_up_link']['url'] ?? '';
         $metrics = !empty($settings['metrics']) ? $settings['metrics'] : array();
 
         array_unshift($metrics, [

--- a/wp-content/themes/academyAfrica/includes/widgets/my_courses.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/my_courses.php
@@ -328,18 +328,18 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                                 $pr_2 = $previous_page - 1;
                                 $next_2 = $next_page + 2;
                                 ?>
-                                <?php for ($i = 1; $i <= $my_courses_pagination['total_pages']; $i++) : ?>
+                                <?php for ($i = 1; $i <= ($my_courses_pagination['total_pages'] ?? 0); $i++) : ?>
                                     <?php
                                     $current_url_params["courses_page"] = $i;
                                     $new_url = add_query_arg($current_url_params, home_url($_SERVER['REQUEST_URI']));
-                                    if ($i === $previous_page || $i === $next_page || $i === $my_courses_pagination['total_pages'] || $i === 1 || $i === $current_page) {
+                                    if ($i === $previous_page || $i === $next_page || $i === ($my_courses_pagination['total_pages'] ?? 0) || $i === 1 || $i === $current_page) {
                                     ?>
                                         <li class="page-item"><a class="page-link" href="<?php echo $new_url ?>">
                                                 <?php echo $i; ?>
                                             </a></li>
                                     <?php
                                     }
-                                    if (($i === $next_2 && $next_2 < $my_courses_pagination['total_pages']) || $i === $pr_2 && $i > 1) {
+                                    if (($i === $next_2 && $next_2 < ($my_courses_pagination['total_pages'] ?? 0)) || $i === $pr_2 && $i > 1) {
                                     ?>
                                         <li style="margin-top: 6px">...</li>
                                 <?php
@@ -470,7 +470,7 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                                 </li>
 
                                 <!-- Page links -->
-                                <?php for ($i = 1; $i <= $certificate_pagination['total_pages']; $i++) : ?>
+                                <?php for ($i = 1; $i <= ($certificate_pagination['total_pages'] ?? 0); $i++) : ?>
                                     <?php
                                     $current_url_params = $_GET;
                                     $current_url_params["courses_page"] = $i;

--- a/wp-content/themes/academyAfrica/posts/footer.php
+++ b/wp-content/themes/academyAfrica/posts/footer.php
@@ -24,8 +24,10 @@ function create_footer_post_type()
         'has_archive'   => true,
         'menu_position' => 5,
         'supports'      => array('title', 'editor', 'thumbnail',),
-        'rewrite'       => array('slug' => 'Footers'),
+        'rewrite'       => array('slug' => 'footers'),
     );
 
-    register_post_type('Footer', $args);
+    // Post-type key is lowercase to match the `post_type => 'footer'` query in
+    // template-parts/footer.php (post-type keys are case-sensitive).
+    register_post_type('footer', $args);
 }

--- a/wp-content/themes/academyAfrica/single-resource.php
+++ b/wp-content/themes/academyAfrica/single-resource.php
@@ -7,7 +7,7 @@ get_header();
 $course_id = get_the_ID();
 
 $course_price = learndash_get_course_price($course_id);
-$price = $course_price['price'] ? $course_price['price'] : 'Free';
+$price = !empty($course_price['price']) ? $course_price['price'] : 'Free';
 $user_id = get_current_user_id();
 $user_courses = learndash_user_get_enrolled_courses($user_id);
 $is_enrolled = in_array($course_id, $user_courses);
@@ -16,7 +16,7 @@ $related_courses = get_field('related_courses', $course_id);
 $short_description = get_field('short_description', $course_id);
 $course_status = learndash_course_status($course_id);
 $post_data = get_post($course_id);
-$course_intro    = $post_data->post_content;
+$course_intro    = $post_data ? $post_data->post_content : '';
 ?>
 
 <style>

--- a/wp-content/themes/academyAfrica/template-parts/footer.php
+++ b/wp-content/themes/academyAfrica/template-parts/footer.php
@@ -80,14 +80,26 @@ if (empty($custom_posts)) {
     $custom_posts = get_posts($search);
 }
 
-$footer = $custom_posts[0];
-$logo = get_post_meta($footer->ID, 'logo', true);
-$thumbnail_url = wp_get_attachment_image_src($logo, 100)[0] ?? '';
-$site_description = get_post_meta($footer->ID, 'site_description', true);
-$stay_in_touch = get_post_meta($footer->ID, 'stay_in_touch', true);
-$secondary_links = get_post_meta($footer->ID, 'secondary_links', true);
-$newsletter = get_post_meta($footer->ID, 'newsletter', true);
-$newsletter_title = get_post_meta($footer->ID, 'newsletter_title', true);
+// A footer post may not exist (e.g. none published for this language and no
+// English fallback). Guard against it so the site chrome renders an intentional
+// empty state instead of emitting warnings on a null post.
+$footer = !empty($custom_posts) ? $custom_posts[0] : null;
+
+if ($footer instanceof \WP_Post) {
+    $logo             = get_post_meta($footer->ID, 'logo', true);
+    $site_description = get_post_meta($footer->ID, 'site_description', true);
+    $stay_in_touch    = get_post_meta($footer->ID, 'stay_in_touch', true);
+    $secondary_links  = get_post_meta($footer->ID, 'secondary_links', true);
+    $newsletter       = get_post_meta($footer->ID, 'newsletter', true);
+    $newsletter_title = get_post_meta($footer->ID, 'newsletter_title', true);
+} else {
+    $logo = $site_description = $stay_in_touch = $secondary_links = $newsletter = $newsletter_title = '';
+}
+
+// wp_get_attachment_image_src() returns false for an empty/invalid attachment;
+// guard the [0] offset so we never index a bool.
+$logo_src      = $logo ? wp_get_attachment_image_src($logo, 100) : false;
+$thumbnail_url = is_array($logo_src) ? $logo_src[0] : '';
 
 ?>
 <footer class="footer-wrapper">


### PR DESCRIPTION
Closes #50

Audit findings 24–26 and the non-event parts of 39.

## Post-type configuration
- **`hierarchical` typo**: `create_organization_post_type()` and `create_learning_path_post_type()` passed `"heirarchical" => true`. `register_post_type` ignores the unknown key, so both types stayed non-hierarchical despite their `page-attributes` support. Fixed to `hierarchical`.
- **Footer key casing**: the footer post type was registered as `'Footer'` but queried as `post_type => 'footer'` (`template-parts/footer.php`). Post-type keys are case-sensitive, so the query matched nothing and the footer's dynamic content silently never loaded. Registered under the lowercase `footer` key and lowercased its rewrite slug.
- **One-time maintenance** (`init`, priority 20, option-guarded): migrates any legacy `Footer` posts to `footer` and flushes rewrite rules, so the corrected hierarchy and the footer key/slug take effect without a manual Permalinks re-save — and existing footer content resurfaces.

## Missing-record / optional-data guards
Intentional empty states instead of PHP warnings:
- **Footer template**: guards the missing footer post (`$custom_posts[0]` / `$footer->ID` on null) and the `wp_get_attachment_image_src(...)[0]` offset-on-`false`. Uses the global `\WP_Post` (the file is namespaced, so an unqualified `WP_Post` would resolve to a non-existent class and always be false).
- **My Courses pager**: `['total_pages'] ?? 0` for both the courses and certificates pagers.
- **Profile**: `$user_meta['description'][0] ?? ''`.
- **Elementor link/image widgets**: nested `['url']` sub-keys default to `''` (hero sign-up, header image, connect join-us).
- **single-resource.php**: guards the LearnDash price key and a null `get_post()`.

## Done when
- ✅ Missing optional data produces intentional empty states without warnings
- ✅ Post-type registration and queries use consistent keys
- ✅ Hierarchy behaves as configured after rewrite rules are refreshed (auto-flushed once)