### PR TITLE
fix(theme): harden frontend JavaScript, markup, and output handling (#55)

### DIFF
--- a/wp-content/themes/academyAfrica/404.php
+++ b/wp-content/themes/academyAfrica/404.php
@@ -14,10 +14,8 @@ if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly.
 }
 ?>
-<?php get_template_part('template-parts/404', 'template'); ?>
-
-</main><?php // close the single <main> opened via get_header() in template-parts/404 ?>
-
-</body>
-
-</html>
+<?php
+// template-parts/404 renders a complete document: it calls get_header()
+// (opens <main>) and get_footer() (footer.php closes <main>, </body>, </html>).
+get_template_part('template-parts/404', 'template');
+?>

--- a/wp-content/themes/academyAfrica/404.php
+++ b/wp-content/themes/academyAfrica/404.php
@@ -3,9 +3,7 @@
 namespace AcademyAfrica\Theme;
 
 /**
- * The template for displaying the footer.
- *
- * Contains the body & html closing tags.
+ * The template for displaying 404 (not found) pages.
  *
  * @package Academy Africa
  */
@@ -15,7 +13,8 @@ if (!defined('ABSPATH')) {
 }
 ?>
 <?php
-// template-parts/404 renders a complete document: it calls get_header()
-// (opens <main>) and get_footer() (footer.php closes <main>, </body>, </html>).
+// template-parts/404 renders a complete document: get_header() and get_footer()
+// emit no <main>, and the part opens and closes its own single
+// <main id="content">. This wrapper adds no markup of its own.
 get_template_part('template-parts/404', 'template');
 ?>

--- a/wp-content/themes/academyAfrica/404.php
+++ b/wp-content/themes/academyAfrica/404.php
@@ -16,6 +16,8 @@ if (!defined('ABSPATH')) {
 ?>
 <?php get_template_part('template-parts/404', 'template'); ?>
 
+</main><?php // close the single <main> opened via get_header() in template-parts/404 ?>
+
 </body>
 
 </html>

--- a/wp-content/themes/academyAfrica/assets/js/header.js
+++ b/wp-content/themes/academyAfrica/assets/js/header.js
@@ -4,13 +4,19 @@ document.addEventListener("DOMContentLoaded", () => {
   const closeIcon = document.querySelector(".icon.close");
   const drawer = document.querySelector(".drawer");
 
-  hamburger.addEventListener("click", () => {
-    drawer.classList.toggle("open");
-    openIcon.style.display =
-      openIcon.style.display === "none" ? "block" : "none";
-    closeIcon.style.display =
-      closeIcon.style.display === "none" ? "block" : "none";
-  });
+  if (hamburger && drawer) {
+    hamburger.addEventListener("click", () => {
+      drawer.classList.toggle("open");
+      if (openIcon) {
+        openIcon.style.display =
+          openIcon.style.display === "none" ? "block" : "none";
+      }
+      if (closeIcon) {
+        closeIcon.style.display =
+          closeIcon.style.display === "none" ? "block" : "none";
+      }
+    });
+  }
 
   const parentNavs = document.querySelectorAll(".item.parent");
 
@@ -18,13 +24,14 @@ document.addEventListener("DOMContentLoaded", () => {
     const childNav = parentNav.querySelector(".children");
     parentNav.addEventListener("click", () => {
       parentNav.classList.toggle("open");
-      childNav.classList.toggle("open");
+      if (childNav) childNav.classList.toggle("open");
 
       // close other open navs
       parentNavs.forEach((nav) => {
         if (nav !== parentNav) {
           nav.classList.remove("open");
-          nav.querySelector(".children").classList.remove("open");
+          const otherChild = nav.querySelector(".children");
+          if (otherChild) otherChild.classList.remove("open");
         }
       });
 
@@ -32,7 +39,7 @@ document.addEventListener("DOMContentLoaded", () => {
       document.addEventListener("click", (e) => {
         if (!parentNav.contains(e.target)) {
           parentNav.classList.remove("open");
-          childNav.classList.remove("open");
+          if (childNav) childNav.classList.remove("open");
         }
       });
     });
@@ -43,24 +50,24 @@ document.addEventListener("DOMContentLoaded", () => {
   const searchClose = document.querySelectorAll("#search-close-btn");
   const mobileNav = document.querySelector("#mobile-nav");
 
+  const toggleSearch = () => {
+    if (searchForm) searchForm.classList.toggle("open");
+    if (mobileNav) mobileNav.classList.toggle("d-none");
+  };
 
-  searchIcon.addEventListener("click", () => {
-    searchForm.classList.toggle("open");
-    mobileNav.classList.toggle("d-none");
-  });
+  if (searchIcon) {
+    searchIcon.addEventListener("click", toggleSearch);
+  }
 
   searchClose.forEach((element) => {
-    element.addEventListener("click", () => {
-    searchForm.classList.toggle("open");
-    mobileNav.classList.toggle("d-none");
-  })
+    element.addEventListener("click", toggleSearch);
   });
 
 
   const signInMenu = document.querySelectorAll("a[href='#sign-in']");
   Array.from(signInMenu).forEach((element) => {
     element.addEventListener("click", function () {
-      openModal("login");
+      if (typeof openModal === "function") openModal("login");
     });
   });
 
@@ -72,8 +79,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const navText = element.querySelector(".collapsible");
 
     const user_avatar = document.querySelector(".user-avatar");
-    if (user_avatar) {
+    if (user_avatar && navText) {
       navText.innerHTML = user_avatar.outerHTML;
-    } 
+    }
   });
 });

--- a/wp-content/themes/academyAfrica/assets/js/search.js
+++ b/wp-content/themes/academyAfrica/assets/js/search.js
@@ -44,6 +44,7 @@ function parseQueryString(queryString) {
 
 function applyFilters(){
     const filterModal = document.querySelector("#filter-modal");
+    if (!filterModal) return;
     searchFilters = {};
 
     // get all checked inputs

--- a/wp-content/themes/academyAfrica/assets/js/widgets/learndash_course_grid.js
+++ b/wp-content/themes/academyAfrica/assets/js/widgets/learndash_course_grid.js
@@ -7,6 +7,7 @@ document.addEventListener("DOMContentLoaded", () => {
         course_items.forEach(course => {
             const price_ribbon = course.querySelector(".ribbon");
             const bottom_meta = course.querySelector(".bottom-meta");
+            if (!price_ribbon || !bottom_meta) return;
             const price = price_ribbon.textContent;
             add_price_tag(price, bottom_meta)
         });

--- a/wp-content/themes/academyAfrica/contact-us.php
+++ b/wp-content/themes/academyAfrica/contact-us.php
@@ -9,10 +9,10 @@ $email_label = get_theme_mod('email_label', 'Email');
 $name_label = get_theme_mod('name_label', 'Name');
 $save_label = get_theme_mod('save_label', 'Submit');
 ?>
-<main class="contact-us">
+<div class="contact-us">
   <?php
   echo do_shortcode('[contact-form-7 id="9521ba1" title="Contact form 1"]');
   ?>
-</main>
+</div>
 <?php
 get_footer();

--- a/wp-content/themes/academyAfrica/contact-us.php
+++ b/wp-content/themes/academyAfrica/contact-us.php
@@ -9,10 +9,10 @@ $email_label = get_theme_mod('email_label', 'Email');
 $name_label = get_theme_mod('name_label', 'Name');
 $save_label = get_theme_mod('save_label', 'Submit');
 ?>
-<div class="contact-us">
+<main id="content" class="contact-us">
   <?php
   echo do_shortcode('[contact-form-7 id="9521ba1" title="Contact form 1"]');
   ?>
-</div>
+</main>
 <?php
 get_footer();

--- a/wp-content/themes/academyAfrica/edit-profile.php
+++ b/wp-content/themes/academyAfrica/edit-profile.php
@@ -99,7 +99,7 @@ if (is_user_logged_in()) {
     $user_networks = explode(",", get_user_meta($user_id, 'networks', true));
     $user_updates = explode(",", get_user_meta($user_id, 'updates', true));
 ?>
-    <div class="profile">
+    <main id="content" class="profile">
         <h4 class="cfa-title">
             <?php echo $page_title ?>
         </h4>
@@ -365,7 +365,7 @@ if (is_user_logged_in()) {
                 }
             }
         </script>
-    </div>
+    </main>
 <?php
 } else {
     echo 'Please log in to edit your profile.';

--- a/wp-content/themes/academyAfrica/edit-profile.php
+++ b/wp-content/themes/academyAfrica/edit-profile.php
@@ -368,7 +368,9 @@ if (is_user_logged_in()) {
     </main>
 <?php
 } else {
-    echo 'Please log in to edit your profile.';
+    // Logged-out state still needs a single main landmark / #content target,
+    // since header.php no longer emits one.
+    echo '<main id="content" class="profile"><p>' . esc_html__('Please log in to edit your profile.', 'academy-africa') . '</p></main>';
 }
 ?>
 

--- a/wp-content/themes/academyAfrica/edit-profile.php
+++ b/wp-content/themes/academyAfrica/edit-profile.php
@@ -99,7 +99,7 @@ if (is_user_logged_in()) {
     $user_networks = explode(",", get_user_meta($user_id, 'networks', true));
     $user_updates = explode(",", get_user_meta($user_id, 'updates', true));
 ?>
-    <main class="profile">
+    <div class="profile">
         <h4 class="cfa-title">
             <?php echo $page_title ?>
         </h4>
@@ -358,14 +358,14 @@ if (is_user_logged_in()) {
                     const reader = new FileReader();
 
                     reader.onload = function(e) {
-                        preview.src = e.target.result;
+                        if (preview) preview.src = e.target.result;
                     };
 
                     reader.readAsDataURL(file);
                 }
             }
         </script>
-    </main>
+    </div>
 <?php
 } else {
     echo 'Please log in to edit your profile.';

--- a/wp-content/themes/academyAfrica/footer.php
+++ b/wp-content/themes/academyAfrica/footer.php
@@ -14,6 +14,8 @@ if (!defined('ABSPATH')) {
 	exit; // Exit if accessed directly.
 }
 ?>
+</main><?php // close the single <main> opened in header.php ?>
+
 <?php get_template_part('template-parts/footer', 'template'); ?>
 
 <?php wp_footer(); ?>

--- a/wp-content/themes/academyAfrica/footer.php
+++ b/wp-content/themes/academyAfrica/footer.php
@@ -14,8 +14,6 @@ if (!defined('ABSPATH')) {
 	exit; // Exit if accessed directly.
 }
 ?>
-</main><?php // close the single <main> opened in header.php ?>
-
 <?php get_template_part('template-parts/footer', 'template'); ?>
 
 <?php wp_footer(); ?>

--- a/wp-content/themes/academyAfrica/header.php
+++ b/wp-content/themes/academyAfrica/header.php
@@ -30,13 +30,17 @@ $skip_link_url = apply_filters('hello_elementor_skip_link_url', '#content');
 </head>
 
 <body <?php body_class(); ?>>
-	<main>
-		<?php wp_body_open(); ?>
+	<?php wp_body_open(); ?>
 
-		<?php if ($enable_skip_link) { ?>
-			<a class="skip-link screen-reader-text" href="<?php echo esc_url($skip_link_url); ?>"><?php echo esc_html__('Skip to content', 'hello-elementor'); ?></a>
-		<?php } ?>
+	<?php if ($enable_skip_link) { ?>
+		<a class="skip-link screen-reader-text" href="<?php echo esc_url($skip_link_url); ?>"><?php echo esc_html__('Skip to content', 'hello-elementor'); ?></a>
+	<?php } ?>
 
-		<!-- get header template -->
+	<!-- site navigation — kept outside <main> -->
 
-		<?php get_template_part('template-parts/header', 'template'); ?>
+	<?php get_template_part('template-parts/header', 'template'); ?>
+
+	<?php // Single <main> landmark per document. Page templates and widgets render
+	// their content inside this element (they no longer open their own <main>).
+	// Closed in footer.php, and in 404.php which doesn't call get_footer(). ?>
+	<main id="content">

--- a/wp-content/themes/academyAfrica/header.php
+++ b/wp-content/themes/academyAfrica/header.php
@@ -36,11 +36,11 @@ $skip_link_url = apply_filters('hello_elementor_skip_link_url', '#content');
 		<a class="skip-link screen-reader-text" href="<?php echo esc_url($skip_link_url); ?>"><?php echo esc_html__('Skip to content', 'hello-elementor'); ?></a>
 	<?php } ?>
 
-	<!-- site navigation — kept outside <main> -->
+	<!-- site navigation -->
 
 	<?php get_template_part('template-parts/header', 'template'); ?>
 
-	<?php // Single <main> landmark per document. Page templates and widgets render
-	// their content inside this element (they no longer open their own <main>).
-	// Closed in footer.php, and in 404.php which doesn't call get_footer(). ?>
-	<main id="content">
+	<?php // Note: header.php intentionally opens no <main>, matching the parent
+	// hello-elementor contract. Each view provides its own single
+	// <main id="content"> (parent template-parts on fallback routes; the child
+	// page templates below on their own routes). ?>

--- a/wp-content/themes/academyAfrica/includes/widgets/all_courses.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/all_courses.php
@@ -267,7 +267,7 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
 
 
 ?>
-        <main class="all-courses">
+        <div class="all-courses">
             <div class="desktop-only">
                 <?php get_template_part('template-parts/filter_bar', 'template', [
                     'filter_by' => $filter_by,
@@ -516,7 +516,7 @@ class Academy_Africa_All_Courses  extends \Elementor\Widget_Base
                 }
                 ?>
             </div>
-        </main>
+        </div>
 <?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/events.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/events.php
@@ -364,7 +364,7 @@ class Academy_Africa_Events  extends \Elementor\Widget_Base
         $previous_events_title = $settings["previous_events_title"];
         $filter_options = $this->get_filter_by();
 ?>
-        <main class="events">
+        <div class="events">
             <aside class="filter-sidebar">
                 <div class="sidebar" id="sidebar">
                     <p class="filter-by">
@@ -685,7 +685,7 @@ class Academy_Africa_Events  extends \Elementor\Widget_Base
                 }
                 ?>
             </section>
-        </main>
+        </div>
 <?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/home_learning_pathways.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/home_learning_pathways.php
@@ -142,7 +142,7 @@ class Academy_Africa_Home_Learning_Pathways  extends \Elementor\Widget_Base
 
 
 ?>
-        <main class="all-courses" id="all-courses">
+        <div class="all-courses" id="all-courses">
             <section class="learning-pathways home-learning-pathways">
                 <div class="title">
                     <h4 class="cfa-title">
@@ -202,7 +202,7 @@ class Academy_Africa_Home_Learning_Pathways  extends \Elementor\Widget_Base
 
                 </div>
             </section>
-        </main>
+        </div>
 <?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/learning_pathways.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/learning_pathways.php
@@ -152,7 +152,7 @@ class Academy_Africa_Learning_Pathways  extends \Elementor\Widget_Base
 
 
 ?>
-        <main class="all-courses" id="all-courses">
+        <div class="all-courses" id="all-courses">
             <?php get_template_part('template-parts/filter_bar', 'template', [
                 'filter_by' => $filter_by,
                 'sort_options' => $sort_options,
@@ -266,7 +266,7 @@ class Academy_Africa_Learning_Pathways  extends \Elementor\Widget_Base
                     ?>
                 </section>
             </div>
-        </main>
+        </div>
 <?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/my_courses.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/my_courses.php
@@ -169,7 +169,7 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
             "last_name" => get_user_meta($user_id, 'last_name', true),
         );
 ?>
-        <main class="body">
+        <div class="body">
             <div class="desktop-only">
                 <?php get_template_part('template-parts/filter_bar', 'template', [
                     'filter_by' => $filter_by,
@@ -500,6 +500,7 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
             </div>
             <script type="text/javascript">
                 function convertHTMLtoPDF(id, courseTitle) {
+                    if (!window.jspdf) return;
                     const {
                         jsPDF
                     } = window.jspdf;
@@ -548,7 +549,7 @@ class Academy_Africa_My_Courses extends \Elementor\Widget_Base
                     }
                 });
             </script>
-        </main>
+        </div>
 <?php
     }
 }

--- a/wp-content/themes/academyAfrica/includes/widgets/slider.php
+++ b/wp-content/themes/academyAfrica/includes/widgets/slider.php
@@ -128,6 +128,7 @@ class Academy_Africa_Slider  extends \Elementor\Widget_Base
         </div>
         <script>
             window.addEventListener('load', function () {
+                if (typeof Swiper === 'undefined') return;
                 new Swiper(".mySwiper", {
                     spaceBetween: 100,
                     centeredSlides: true,

--- a/wp-content/themes/academyAfrica/login.php
+++ b/wp-content/themes/academyAfrica/login.php
@@ -15,8 +15,10 @@ function get_template(){
 }
 
 get_header();
+echo '<main id="content">';
 $template = get_template();
 get_template_part($template, 'template');
+echo '</main>';
 get_footer();
 
 ?>

--- a/wp-content/themes/academyAfrica/page-content.php
+++ b/wp-content/themes/academyAfrica/page-content.php
@@ -6,7 +6,7 @@ require_once(ABSPATH . 'wp-load.php');
 get_header();
 
 ?>
-<div class="about-section">
+<main id="content" class="about-section">
     <div class="content">
         <?php
         if (have_posts()) {
@@ -19,6 +19,6 @@ get_header();
         }
         ?>
     </div>
-</div>
+</main>
 <?php
 get_footer();

--- a/wp-content/themes/academyAfrica/page-content.php
+++ b/wp-content/themes/academyAfrica/page-content.php
@@ -6,7 +6,7 @@ require_once(ABSPATH . 'wp-load.php');
 get_header();
 
 ?>
-<main class="about-section">
+<div class="about-section">
     <div class="content">
         <?php
         if (have_posts()) {
@@ -19,6 +19,6 @@ get_header();
         }
         ?>
     </div>
-</main>
+</div>
 <?php
 get_footer();

--- a/wp-content/themes/academyAfrica/search.php
+++ b/wp-content/themes/academyAfrica/search.php
@@ -92,7 +92,7 @@ if ($no_of_pages > 1 && $current_page <= $no_of_pages) {
 ?>
 
 <?php get_header(); ?>
-<div class="search-page">
+<main id="content" class="search-page">
     <?php get_template_part('template-parts/filter_bar', 'template', [
         'filter_by' => $filter_by,
         'filter_options' => $filter_options,
@@ -289,7 +289,7 @@ if ($no_of_pages > 1 && $current_page <= $no_of_pages) {
             </div>
         </div>
     </div>
-</div>
+</main>
 
 
 

--- a/wp-content/themes/academyAfrica/search.php
+++ b/wp-content/themes/academyAfrica/search.php
@@ -109,7 +109,7 @@ if ($no_of_pages > 1 && $current_page <= $no_of_pages) {
                     <?php echo $the_query->found_posts ?> results for:
                 </p>
                 <h1 class="search-page-title">
-                    "<?php echo $s ?>"
+                    "<?php echo esc_html($s) ?>"
                 </h1>
 
             </div>
@@ -128,7 +128,7 @@ if ($no_of_pages > 1 && $current_page <= $no_of_pages) {
                             foreach ($sort_options as $key => $option) {
                                 $selected = $sort == $key ? "selected" : "";
                             ?>
-                                <option <?php echo $selected ?> value="<?php echo $key ?>"><?php echo $option["name"] ?></option>
+                                <option <?php echo $selected ?> value="<?php echo esc_attr($key) ?>"><?php echo esc_html($option["name"]) ?></option>
                             <?php
                             }
                             ?>
@@ -159,9 +159,9 @@ if ($no_of_pages > 1 && $current_page <= $no_of_pages) {
                         ?>
                             <div class="filter">
                                 <div class="filter-name">
-                                    <?php echo $org ?>
+                                    <?php echo esc_html($org) ?>
                                 </div>
-                                <button class="filter-remove" onclick="removeFilter('organization', '<?php echo $org ?>')">
+                                <button class="filter-remove" onclick="removeFilter('organization', '<?php echo esc_js($org) ?>')">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="17" viewBox="0 0 16 17" fill="none">
                                         <path d="M8.0026 15.1693C11.6845 15.1693 14.6693 12.1845 14.6693 8.5026C14.6693 4.82071 11.6845 1.83594 8.0026 1.83594C4.32071 1.83594 1.33594 4.82071 1.33594 8.5026C1.33594 12.1845 4.32071 15.1693 8.0026 15.1693Z" stroke="#0C1A81" stroke-linecap="round" stroke-linejoin="round" />
                                         <path d="M10 6.5L6 10.5" stroke="#0C1A81" stroke-linecap="round" stroke-linejoin="round" />
@@ -255,7 +255,7 @@ if ($no_of_pages > 1 && $current_page <= $no_of_pages) {
                     <?php
                     if ($current_page > 1) {
                     ?>
-                        <li class="page-item"><a class="page-link" href="<?php echo get_pagenum_link($current_page - 1) ?>">
+                        <li class="page-item"><a class="page-link" href="<?php echo esc_url(get_pagenum_link($current_page - 1)) ?>">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
                                     <path d="M10 12L6 8L10 4" stroke="#616582" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
                                 </svg>
@@ -266,18 +266,18 @@ if ($no_of_pages > 1 && $current_page <= $no_of_pages) {
                         if ($i == $current_page) {
                         ?>
                             <li class="page-item active">
-                                <a class="page-link" href="<?php echo get_pagenum_link($i) ?>"><?php echo $i ?></a>
+                                <a class="page-link" href="<?php echo esc_url(get_pagenum_link($i)) ?>"><?php echo $i ?></a>
                             </li>
                         <?php
                         } else {
                         ?>
-                            <li class="page-item"><a class="page-link" href="<?php echo get_pagenum_link($i) ?>"><?php echo $i ?></a></li>
+                            <li class="page-item"><a class="page-link" href="<?php echo esc_url(get_pagenum_link($i)) ?>"><?php echo $i ?></a></li>
                         <?php
                         }
                     }
                     if ($current_page < $no_of_pages) {
                         ?>
-                        <li class="page-item"><a class="page-link" href="<?php echo get_pagenum_link($current_page + 1) ?>">
+                        <li class="page-item"><a class="page-link" href="<?php echo esc_url(get_pagenum_link($current_page + 1)) ?>">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
                                     <path d="M6 12L10 8L6 4" stroke="#616582" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
                                 </svg>

--- a/wp-content/themes/academyAfrica/searchform.php
+++ b/wp-content/themes/academyAfrica/searchform.php
@@ -13,7 +13,7 @@
     // Track the search form submission
     document.getElementById('searchform').addEventListener('submit', function() {
         var searchTerm = document.getElementById('s').value;
-        gtag('event', 'search', {
+        typeof window.gtag === 'function' && gtag('event', 'search', {
             'event_category': 'engagement',
             'event_label': searchTerm
         });

--- a/wp-content/themes/academyAfrica/single-ac-learning-path.php
+++ b/wp-content/themes/academyAfrica/single-ac-learning-path.php
@@ -14,7 +14,7 @@ $courses = get_field('courses', $learning_path_id) ?: [];
 <?php get_header(); ?>
 
 
-<div class="ac-learning-path-container">
+<main id="content" class="ac-learning-path-container">
     <div id='learning-path'>
         <div class="ac-learning-path-container__title">
             <div class="ac-learning-path-container__title__image">
@@ -98,7 +98,7 @@ $courses = get_field('courses', $learning_path_id) ?: [];
             Download as PDF
         </button>
     </div>
-</div>
+</main>
 
 <script type="text/javascript">
     function downloadSingleLearningPath() {

--- a/wp-content/themes/academyAfrica/single-ac-learning-path.php
+++ b/wp-content/themes/academyAfrica/single-ac-learning-path.php
@@ -68,11 +68,11 @@ $courses = get_field('courses', $learning_path_id) ?: [];
                                     ]
                                 ); ?>
                                 <div class="extra-course-details">
-                                    <a href="<?php echo $course_link ?>" class="course-title">
-                                        <?php echo $course_title ?>
+                                    <a href="<?php echo esc_url($course_link) ?>" class="course-title">
+                                        <?php echo esc_html($course_title) ?>
                                     </a>
                                     <div class="course-excerpt">
-                                        <?php echo $course_excerpt ?>
+                                        <?php echo esc_html($course_excerpt) ?>
                                     </div>
                                 </div>
                             </div>
@@ -102,12 +102,15 @@ $courses = get_field('courses', $learning_path_id) ?: [];
 
 <script type="text/javascript">
     function downloadSingleLearningPath() {
-        var printTemplate = document.getElementById('learning').innerHTML;
+        var printSource = document.getElementById('learning');
+        if (!printSource) return;
+        var printTemplate = printSource.innerHTML;
 
         var printWindow = window.open('', '', '');
+        if (!printWindow) return;
         printWindow.document.write('<!DOCTYPE html>');
         printWindow.document.write('<html><head>');
-        printWindow.document.write('<title><?php echo addslashes($learning_path_title); ?></title>');
+        printWindow.document.write('<title><?php echo esc_js($learning_path_title); ?></title>');
         printWindow.document.write('</head><body>');
         printWindow.document.write(printTemplate);
         printWindow.document.write('</body></html>');
@@ -122,11 +125,11 @@ $courses = get_field('courses', $learning_path_id) ?: [];
     window.dataLayer = window.dataLayer || [];
     dataLayer.push({
         'event': 'learning_path_print',
-        'page_title': '<?php echo $learning_path_title ?>',
+        'page_title': '<?php echo esc_js($learning_path_title) ?>',
         'page_url': window.location.href,
     });
-    gtag('event', 'learning_path_print', {
-        'page_title': '<?php echo $learning_path_title ?>',
+    typeof window.gtag === 'function' && gtag('event', 'learning_path_print', {
+        'page_title': '<?php echo esc_js($learning_path_title) ?>',
         'page_location': window.location.href,
     });
 </script>

--- a/wp-content/themes/academyAfrica/single-ac-learning-path.php
+++ b/wp-content/themes/academyAfrica/single-ac-learning-path.php
@@ -125,11 +125,11 @@ $courses = get_field('courses', $learning_path_id) ?: [];
     window.dataLayer = window.dataLayer || [];
     dataLayer.push({
         'event': 'learning_path_print',
-        'page_title': '<?php echo esc_js($learning_path_title) ?>',
+        'page_title': <?php echo wp_json_encode($learning_path_title) ?>,
         'page_url': window.location.href,
     });
     typeof window.gtag === 'function' && gtag('event', 'learning_path_print', {
-        'page_title': '<?php echo esc_js($learning_path_title) ?>',
+        'page_title': <?php echo wp_json_encode($learning_path_title) ?>,
         'page_location': window.location.href,
     });
 </script>

--- a/wp-content/themes/academyAfrica/single-event.php
+++ b/wp-content/themes/academyAfrica/single-event.php
@@ -10,7 +10,7 @@ $or_title = "The Organisation";
 $speaker_title = "The Speaker";
 require_once __DIR__ . '/includes/utils/countries.php';
 ?>
-<main id="main" class="single-page-event">
+<div id="main" class="single-page-event">
     <?php
     if (have_posts()):
         while (have_posts()):
@@ -38,28 +38,28 @@ require_once __DIR__ . '/includes/utils/countries.php';
             $countries = get_field("countries", $post_id) ?: [];
     ?>
             <h1 class="cfa-title">
-                <?php echo $post_title ?>
+                <?php echo esc_html($post_title) ?>
             </h1>
             <div class="image-container">
-                <img width="100%" class="featured-image" src="<?php echo $featured_image_url ?>"
-                    alt="<?php echo $post_id ?>">
+                <img width="100%" class="featured-image" src="<?php echo esc_url($featured_image_url) ?>"
+                    alt="<?php echo esc_attr($post_title) ?>">
             </div>
             <div class="details">
                 <div class="custom-data">
                     <p class="speaker">
-                        <?php echo isset($speaker) ? $speaker->display_name : "" ?>
+                        <?php echo isset($speaker) ? esc_html($speaker->display_name) : "" ?>
                     </p>
                     <div class="with-icons">
                         <img src="/wp-content/themes/academyAfrica/assets/images/icons/Type=calendar, Size=16, Color=Black.svg" alt="">
                         <p style="margin: 0" class="date">
-                            <?php echo $date ?>
+                            <?php echo esc_html($date) ?>
                         </p>
                     </div>
 
                     <div class="with-icons">
                         <img src="/wp-content/themes/academyAfrica/assets/images/icons/Type=world, Size=16, Color=Black.svg" alt="">
                         <p style="margin: 0" class="language">
-                            <?php echo $language ?>
+                            <?php echo esc_html($language) ?>
                         </p>
                     </div>
                     <div class="with-icons">
@@ -84,18 +84,18 @@ require_once __DIR__ . '/includes/utils/countries.php';
                     <?php
                     if ($is_past_event) {
                     ?>
-                        <a href="<?php echo $resources ?>" <?php echo $resources ? 'download' : '' ?>>
+                        <a href="<?php echo esc_url($resources) ?>" <?php echo $resources ? 'download' : '' ?>>
                             <button class="button resources">
                                 <img src="/wp-content/themes/academyAfrica/assets/images/MOOCButton.svg" alt="">
-                                <?php echo $resources_text ?>
+                                <?php echo esc_html($resources_text) ?>
                             </button>
                         </a>
                     <?php
                     } else {
                     ?>
-                        <a href="<?php echo $registration_link ?>">
+                        <a href="<?php echo esc_url($registration_link) ?>">
                             <button class="button cta signup-button">
-                                <?php echo $register_text ?>
+                                <?php echo esc_html($register_text) ?>
                             </button>
                         </a>
 
@@ -106,10 +106,10 @@ require_once __DIR__ . '/includes/utils/countries.php';
             </div>
             <hr class="divider">
             <p class="content">
-                <?php echo $post_content ?>
+                <?php echo wp_kses_post($post_content) ?>
             </p>
             <div class="linked-post">
-                <h4 class="title"><?php echo $speaker_title ?></h4>
+                <h4 class="title"><?php echo esc_html($speaker_title) ?></h4>
 
                 <?php
                 if (isset($speakers) && is_array($speakers) && count($speakers) > 0) {
@@ -118,12 +118,12 @@ require_once __DIR__ . '/includes/utils/countries.php';
                         $avatar_url = get_the_post_thumbnail_url($speaker->ID, 'full');
                         $sp_desc = get_the_excerpt($speaker->ID);
                 ?>
-                        <img style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; margin: 0;" src="<?php echo $avatar_url ?>" alt="<?php echo $speaker->display_name ?>" class="logo">
+                        <img style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; margin: 0;" src="<?php echo esc_url($avatar_url) ?>" alt="<?php echo esc_attr($speaker->display_name) ?>" class="logo">
                         <p style="text-transform: capitalize; margin: 0" class="name">
-                            <?php echo $sp_title ?>
+                            <?php echo esc_html($sp_title) ?>
                         </p>
                         <p class="description" style="margin-bottom: 32px; margin-top: 16px;">
-                            <?php echo $sp_desc ?>
+                            <?php echo esc_html($sp_desc) ?>
                         </p>
                 <?php
                     }
@@ -138,13 +138,13 @@ require_once __DIR__ . '/includes/utils/countries.php';
                     $img = get_the_post_thumbnail_url($organisation->ID, 'full');
                     $desc = get_the_excerpt($organisation->ID);
                 ?>
-                    <h4 class="title"><?php echo $or_title ?></h4>
-                    <img src="<?php echo $img ?>" alt="<?php echo $org_title ?>" style="height: 100px;" class="logo">
+                    <h4 class="title"><?php echo esc_html($or_title) ?></h4>
+                    <img src="<?php echo esc_url($img) ?>" alt="<?php echo esc_attr($org_title) ?>" style="height: 100px;" class="logo">
                     <p class="name">
-                        <?php echo $org_title ?>
+                        <?php echo esc_html($org_title) ?>
                     </p>
                     <p class="description">
-                        <?php echo $desc ?>
+                        <?php echo esc_html($desc) ?>
                     </p>
                 <?php
                 }
@@ -161,10 +161,10 @@ require_once __DIR__ . '/includes/utils/countries.php';
                 <path d="M10 4L6 8L10 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                     stroke-linejoin="round" />
             </svg>
-            <?php echo $back_text ?>
+            <?php echo esc_html($back_text) ?>
         </a>
     </div>
-</main>
+</div>
 
 <?php
 get_footer(); // Include the footer file

--- a/wp-content/themes/academyAfrica/single-event.php
+++ b/wp-content/themes/academyAfrica/single-event.php
@@ -10,7 +10,7 @@ $or_title = "The Organisation";
 $speaker_title = "The Speaker";
 require_once __DIR__ . '/includes/utils/countries.php';
 ?>
-<div id="main" class="single-page-event">
+<main id="content" class="single-page-event">
     <?php
     if (have_posts()):
         while (have_posts()):
@@ -164,7 +164,7 @@ require_once __DIR__ . '/includes/utils/countries.php';
             <?php echo esc_html($back_text) ?>
         </a>
     </div>
-</div>
+</main>
 
 <?php
 get_footer(); // Include the footer file

--- a/wp-content/themes/academyAfrica/single-resource.php
+++ b/wp-content/themes/academyAfrica/single-resource.php
@@ -37,7 +37,7 @@ $course_intro    = $post_data ? $post_data->post_content : '';
                 $course_thumbnail = get_the_post_thumbnail_url($course_id);
                 $mooc_logo = get_stylesheet_directory_uri() . '/assets/images/mooc-logo-blue.svg';
                 $logo_url = $course_thumbnail ? $course_thumbnail : $mooc_logo;
-                echo '<img src="' . $logo_url . '" alt="">';
+                echo '<img src="' . esc_url($logo_url) . '" alt="">';
                 ?>
             </div>
         </div>
@@ -45,7 +45,7 @@ $course_intro    = $post_data ? $post_data->post_content : '';
         if (!empty($short_description)) {
         ?>
             <div class="description">
-                <?php echo $short_description; ?>
+                <?php echo wp_kses_post($short_description); ?>
             </div>
         <?php
         }

--- a/wp-content/themes/academyAfrica/single-resource.php
+++ b/wp-content/themes/academyAfrica/single-resource.php
@@ -24,7 +24,7 @@ $course_intro    = $post_data ? $post_data->post_content : '';
         display: none;
     }
 </style>
-<div class="single-courses wysiwyg">
+<main id="content" class="single-courses wysiwyg">
     <div class="wrapper">
         <div class="title-section">
             <div class="title">
@@ -60,7 +60,7 @@ $course_intro    = $post_data ? $post_data->post_content : '';
             </div>
         </div>
     </div>
-</div>
+</main>
 <?php
 get_footer();
 ?>

--- a/wp-content/themes/academyAfrica/template-parts/404.php
+++ b/wp-content/themes/academyAfrica/template-parts/404.php
@@ -64,7 +64,7 @@ $home = academyafrica_translate('Home');
         }
 
         var notFoundPayload = {
-            'page_title': '<?php echo $title ?>',
+            'page_title': <?php echo wp_json_encode($title) ?>,
             'page_url': window.location.href,
             'status_code': '<?php echo $status_code ?>',
             'not_found_path': window.location.pathname + window.location.search + window.location.hash,

--- a/wp-content/themes/academyAfrica/template-parts/404.php
+++ b/wp-content/themes/academyAfrica/template-parts/404.php
@@ -21,7 +21,7 @@ $description = academyafrica_translate('There seems to be an error on this page.
 $refresh = academyafrica_translate('Refresh');
 $home = academyafrica_translate('Home');
 ?>
-<main id="content" class="site-main" style="margin: 0;">
+<div class="site-main" style="margin: 0;">
 
     <div class="error">
         <div></div>
@@ -92,6 +92,6 @@ $home = academyafrica_translate('Home');
         });
     </script>
 
-</main>
+</div>
 
 <?php get_footer(); ?>

--- a/wp-content/themes/academyAfrica/template-parts/404.php
+++ b/wp-content/themes/academyAfrica/template-parts/404.php
@@ -21,7 +21,7 @@ $description = academyafrica_translate('There seems to be an error on this page.
 $refresh = academyafrica_translate('Refresh');
 $home = academyafrica_translate('Home');
 ?>
-<div class="site-main" style="margin: 0;">
+<main id="content" class="site-main" style="margin: 0;">
 
     <div class="error">
         <div></div>
@@ -92,6 +92,6 @@ $home = academyafrica_translate('Home');
         });
     </script>
 
-</div>
+</main>
 
 <?php get_footer(); ?>

--- a/wp-content/themes/academyAfrica/template-parts/certificate.php
+++ b/wp-content/themes/academyAfrica/template-parts/certificate.php
@@ -82,7 +82,7 @@ $mooc_logo_black = get_stylesheet_directory_uri() . '/assets/images/mooc-logo-bl
         'download_type': 'pdf',
         'date': new Date().toISOString()
       });
-      gtag('event', 'download_certificate', {
+      typeof window.gtag === 'function' && gtag('event', 'download_certificate', {
         'user_id': '<?php echo $args['user']['id'] ?? ''; ?>',
         'course_id': '<?php echo $args['course']['id'] ?? ''; ?>',
         'download_type': 'pdf',

--- a/wp-content/themes/academyAfrica/template-parts/course_card.php
+++ b/wp-content/themes/academyAfrica/template-parts/course_card.php
@@ -41,14 +41,14 @@ $course_index = isset($args['course_index']) ? $args['course_index'] : uniqid();
     </div>
 </a>
 <script>
-    document.getElementById('course-card-<?php echo $course_index ?>').addEventListener('click', function() {
+    document.getElementById('course-card-<?php echo $course_index ?>')?.addEventListener('click', function() {
         window.dataLayer = window.dataLayer || [];
         dataLayer.push({
             'event': 'course_card_click',
             'course_title': '<?php echo $course_title ?>',
             'course_link': '<?php echo $course_link ?>',
         });
-        gtag('event', 'course_card_click', {
+        typeof window.gtag === 'function' && gtag('event', 'course_card_click', {
             'event_category': 'engagement',
             'event_label': '<?php echo $course_title ?>',
             'course_link': '<?php echo $course_link ?>'

--- a/wp-content/themes/academyAfrica/template-parts/course_card.php
+++ b/wp-content/themes/academyAfrica/template-parts/course_card.php
@@ -45,13 +45,13 @@ $course_index = isset($args['course_index']) ? $args['course_index'] : uniqid();
         window.dataLayer = window.dataLayer || [];
         dataLayer.push({
             'event': 'course_card_click',
-            'course_title': '<?php echo $course_title ?>',
-            'course_link': '<?php echo $course_link ?>',
+            'course_title': <?php echo wp_json_encode($course_title) ?>,
+            'course_link': <?php echo wp_json_encode($course_link) ?>,
         });
         typeof window.gtag === 'function' && gtag('event', 'course_card_click', {
             'event_category': 'engagement',
-            'event_label': '<?php echo $course_title ?>',
-            'course_link': '<?php echo $course_link ?>'
+            'event_label': <?php echo wp_json_encode($course_title) ?>,
+            'course_link': <?php echo wp_json_encode($course_link) ?>
         });
     });
 </script>

--- a/wp-content/themes/academyAfrica/template-parts/course_completed.php
+++ b/wp-content/themes/academyAfrica/template-parts/course_completed.php
@@ -113,6 +113,7 @@ global $shortcode_tags;
     </div>
     <script type="text/javascript">
         function convertHTMLtoPDF() {
+            if (!window.jspdf) return;
             const {
                 jsPDF
             } = window.jspdf;
@@ -120,6 +121,7 @@ global $shortcode_tags;
             let doc = new jsPDF('l', 'mm', [210, 297]);
             doc.setFillColor(255, 255, 255);
             let pdfjs = document.getElementById('certificate');
+            if (!pdfjs) return;
             const width = doc.internal.pageSize.getWidth();
             const height = doc.internal.pageSize.getHeight();
             doc.html(pdfjs, {

--- a/wp-content/themes/academyAfrica/template-parts/footer.php
+++ b/wp-content/themes/academyAfrica/template-parts/footer.php
@@ -109,7 +109,11 @@ $thumbnail_url = is_array($logo_src) ? $logo_src[0] : '';
                 <img height="110" width="250"
                     src="<?php echo esc_url($thumbnail_url) ?>" alt="<?php echo esc_attr(get_bloginfo('name')); ?>" class="logo">
                 <p class="description">
-                    <?php echo esc_html($site_description) ?>
+                    <?php
+                    // site_description is a WYSIWYG ACF field — allow safe formatting
+                    // (links, emphasis, paragraphs) while stripping unsafe markup.
+                    echo wp_kses_post($site_description);
+                    ?>
                 </p>
                 <div class="footer-connect">
                     <span style="white-space: nowrap;">

--- a/wp-content/themes/academyAfrica/template-parts/footer.php
+++ b/wp-content/themes/academyAfrica/template-parts/footer.php
@@ -107,13 +107,13 @@ $thumbnail_url = is_array($logo_src) ? $logo_src[0] : '';
         <div class="item">
             <div class="site-description">
                 <img height="110" width="250"
-                    src="<?php echo $thumbnail_url ?>" alt=<?php echo get_bloginfo('name'); ?> class="logo">
+                    src="<?php echo esc_url($thumbnail_url) ?>" alt="<?php echo esc_attr(get_bloginfo('name')); ?>" class="logo">
                 <p class="description">
-                    <?php echo $site_description ?>
+                    <?php echo esc_html($site_description) ?>
                 </p>
                 <div class="footer-connect">
                     <span style="white-space: nowrap;">
-                        <?php echo $stay_in_touch ?>
+                        <?php echo esc_html($stay_in_touch) ?>
                     </span>
                     <div class="social-icons">
                         <?php
@@ -155,11 +155,17 @@ $thumbnail_url = is_array($logo_src) ? $logo_src[0] : '';
         <div class="item">
             <div class="embed">
                 <p class="title">
-                    <?php echo $newsletter_title ?>
+                    <?php echo esc_html($newsletter_title) ?>
                 </p>
                 <div>
-                    <?php echo $newsletter ?>
+                    <?php
+                    // Trusted content: the newsletter field holds an admin-entered
+                    // embed (e.g. a Mailchimp <form>), which wp_kses_post would strip.
+                    // Only site editors can set this meta, so it is output as-is.
+                    echo $newsletter;
+                    ?>
                 </div>
+
             </div>
         </div>
     </div>

--- a/wp-content/themes/academyAfrica/template-parts/header.php
+++ b/wp-content/themes/academyAfrica/template-parts/header.php
@@ -203,7 +203,9 @@ handle_login_failure();
             <?php
             $current_url = get_permalink();
             $logout_url = wp_logout_url(get_permalink());
-            echo "window.location.href = '" . esc_url($logout_url) . "'";
+            // JS context: serialize as a JS value so nonce/redirect query args
+            // survive (esc_url would emit HTML entities that don't decode here).
+            echo "window.location.href = " . wp_json_encode($logout_url) . ";";
             ?>
         });
     });

--- a/wp-content/themes/academyAfrica/template-parts/header.php
+++ b/wp-content/themes/academyAfrica/template-parts/header.php
@@ -108,21 +108,21 @@ handle_login_failure();
                             $class .= ' ' . $menu_item["class"];
                             if (count($menu_item['children']) > 0) {
                                 $class .= ' parent';
-                                echo "<div class='" . $class . "'>";
+                                echo "<div class='" . esc_attr($class) . "'>";
                                 echo
-                                "<span class='collapsible'>" . $menu_item['title'] . "
+                                "<span class='collapsible'>" . esc_html($menu_item['title']) . "
                             </span>";
                                 echo "<div class='children'>";
                                 foreach ($menu_item['children'] as $child) {
                                     echo "
-                            <a class='item' href='" . $child['url'] . "'>" . $child['title'] . "</a>
+                            <a class='item' href='" . esc_url($child['url']) . "'>" . esc_html($child['title']) . "</a>
                             ";
                                 }
                                 echo "</div>";
                                 echo "</div>";
                             } else {
                                 $query_param = $menu_item['class'] == "sign-in" ? '?redirect_url=' . $path_name : '';
-                                echo "<a class='" . $class . "' href='" . $menu_item['url'] . $query_param . "'>" . $menu_item['title'] . "</a>";
+                                echo "<a class='" . esc_attr($class) . "' href='" . esc_url($menu_item['url'] . $query_param) . "'>" . esc_html($menu_item['title']) . "</a>";
                             }
                         }
                         ?>
@@ -140,7 +140,7 @@ handle_login_failure();
             $user = wp_get_current_user();
             $avatar = get_avatar_url($user->ID);
             if ($avatar) {
-                echo "<img class='user-avatar' src='" . $avatar . "' alt='user avatar' />";
+                echo "<img class='user-avatar' src='" . esc_url($avatar) . "' alt='user avatar' />";
             } else {
                 echo "<div class='user-avatar'>";
                 $user = wp_get_current_user();
@@ -168,19 +168,19 @@ handle_login_failure();
                 $class = 'item' . ' ' . $menu_item["class"];
                 if (count($menu_item['children']) > 0) {
                     $class .= ' parent mobile';
-                    echo "<div class='" . $class . "'>";
-                    echo "<span class='collapsible'>" . $menu_item['title'] . "
+                    echo "<div class='" . esc_attr($class) . "'>";
+                    echo "<span class='collapsible'>" . esc_html($menu_item['title']) . "
                     </span>";
                     echo "<div class='children'>";
                     foreach ($menu_item['children'] as $child) {
                         echo "
-                            <a class='item' href='" . $child['url'] . "'>" . $child['title'] . "</a>
+                            <a class='item' href='" . esc_url($child['url']) . "'>" . esc_html($child['title']) . "</a>
                             ";
                     }
                     echo "</div>";
                     echo "</div>";
                 } else {
-                    echo "<a class='" . $class . "' href='" . $menu_item['url'] . "'>" . $menu_item['title'] . "</a>";
+                    echo "<a class='" . esc_attr($class) . "' href='" . esc_url($menu_item['url']) . "'>" . esc_html($menu_item['title']) . "</a>";
                 }
             }
             ?>
@@ -203,7 +203,7 @@ handle_login_failure();
             <?php
             $current_url = get_permalink();
             $logout_url = wp_logout_url(get_permalink());
-            echo "window.location.href = '" . $logout_url . "'";
+            echo "window.location.href = '" . esc_url($logout_url) . "'";
             ?>
         });
     });

--- a/wp-content/themes/academyAfrica/template-parts/login.php
+++ b/wp-content/themes/academyAfrica/template-parts/login.php
@@ -148,13 +148,13 @@ if (isset($_GET['email_sent'])) {
                 btn.value = <?php echo wp_json_encode(academyafrica_translate('SIGN IN')); ?>;
             }
 
-            document.getElementById("wp-submit").addEventListener("click", function() {
+            document.getElementById("wp-submit")?.addEventListener("click", function() {
                 window.dataLayer = window.dataLayer || [];
                 dataLayer.push({
                     'event': 'login',
                     'method': 'standard'
                 });
-                gtag('event', 'login', {
+                typeof window.gtag === 'function' && gtag('event', 'login', {
                     'event_category': 'engagement',
                     'event_label': 'standard'
                 });
@@ -168,7 +168,7 @@ if (isset($_GET['email_sent'])) {
                         'event': 'login_error',
                         'error_message': errorMessage
                     });
-                    gtag('event', 'login_error', {
+                    typeof window.gtag === 'function' && gtag('event', 'login_error', {
                         'event_category': 'engagement',
                         'event_label': errorMessage
                     });
@@ -182,7 +182,7 @@ if (isset($_GET['email_sent'])) {
                         'event': 'login',
                         'method': 'google'
                     });
-                    gtag('event', 'login', {
+                    typeof window.gtag === 'function' && gtag('event', 'login', {
                         'event_category': 'engagement',
                         'event_label': 'google'
                     });

--- a/wp-content/themes/academyAfrica/template-parts/password-reset.php
+++ b/wp-content/themes/academyAfrica/template-parts/password-reset.php
@@ -2,7 +2,10 @@
 
 namespace AcademyAfrica\Theme;
 
-get_header();
+// Rendered as a fragment via login.php's get_template_part(); login.php provides
+// the header, the single <main id="content"> wrapper, and the footer. (It used
+// to call get_header()/get_footer() itself, which produced a nested second
+// header/footer on the lost-password route.)
 function get_full_url($path = '', $search = '')
 {
     $protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http";
@@ -29,7 +32,7 @@ function get_full_url($path = '', $search = '')
             <div style="display:flex; gap: 8px">
                 <span class="description"><?php echo esc_html(academyafrica_translate('You can')); ?> </span>
                 <form action="<?php echo wp_lostpassword_url() ?>" method="post">
-                    <input type="email" placeholder="<?php echo esc_attr(academyafrica_translate('Email')); ?>" id="user_login" name="user_login" value="<?php echo $_GET['user_login'] ?>" required hidden>
+                    <input type="email" placeholder="<?php echo esc_attr(academyafrica_translate('Email')); ?>" id="user_login" name="user_login" value="<?php echo esc_attr(wp_unslash($_GET['user_login'] ?? '')) ?>" required hidden>
                     <input type="text" hidden name="pass_reset" value="pass-reset">
                     <button class="description" style="background: none; border: none; padding: 0; margin: 0; font: inherit; color: #0C1A81; text-decoration: none; cursor: pointer; display: inline;"
                         onmouseover="this.style.textDecoration='underline';"
@@ -92,4 +95,3 @@ function get_full_url($path = '', $search = '')
         }
     </script>
 </div>
-<?php get_footer(); ?>

--- a/wp-content/themes/academyAfrica/template-parts/password-reset.php
+++ b/wp-content/themes/academyAfrica/template-parts/password-reset.php
@@ -84,7 +84,7 @@ function get_full_url($path = '', $search = '')
                 dataLayer.push({
                     'event': 'password_reset'
                 });
-                gtag('event', 'password_reset', {
+                typeof window.gtag === 'function' && gtag('event', 'password_reset', {
                     'event_category': 'engagement',
                     'event_label': 'password_reset'
                 });

--- a/wp-content/themes/academyAfrica/template-parts/register.php
+++ b/wp-content/themes/academyAfrica/template-parts/register.php
@@ -107,11 +107,14 @@ if ($success) {
             </footer>
             <script>
                 function validateForm() {
-                    const password = document.getElementById("password").value;
-                    const confirmPassword = document.getElementById("confirm-password").value;
-                    if (password !== confirmPassword) {
+                    const password = document.getElementById("password");
+                    const confirmPassword = document.getElementById("confirm-password");
+                    if (!password || !confirmPassword) return true;
+                    if (password.value !== confirmPassword.value) {
                         const errorAlert = document.getElementById("error-alert");
-                        errorAlert.innerText = <?php echo wp_json_encode(academyafrica_translate('Passwords do not match')); ?>;
+                        if (errorAlert) {
+                            errorAlert.innerText = <?php echo wp_json_encode(academyafrica_translate('Passwords do not match')); ?>;
+                        }
                         return false;
                     }
                     return true;
@@ -119,6 +122,7 @@ if ($success) {
                 function togglePasswordVisibility(id) {
                     const password = document.getElementById(id);
                     const togglePassword = document.getElementById(`toggle-${id}`);
+                    if (!password || !togglePassword) return;
                     if (password.type === "password") {
                         password.type = "text";
                         togglePassword.innerText = "visibility";
@@ -136,7 +140,7 @@ if ($success) {
                             'event': 'register',
                             'method': 'standard'
                         });
-                        gtag('event', 'register', {
+                        typeof window.gtag === 'function' && gtag('event', 'register', {
                             'event_category': 'engagement',
                             'event_label': 'standard'
                         });

--- a/wp-content/themes/academyAfrica/template-parts/social_share.php
+++ b/wp-content/themes/academyAfrica/template-parts/social_share.php
@@ -44,15 +44,15 @@ $share_message = isset($args["message"]) ? $args["message"] : sprintf(academyafr
                 window.dataLayer = window.dataLayer || [];
                 dataLayer.push({
                     'event': 'share_button_click',
-                    "message": "<?php echo $share_message ?>",
+                    "message": <?php echo wp_json_encode($share_message) ?>,
                     'platform': buttonId.split('-')[2],
-                    'url': "<?php echo $url_to_share ?>",
+                    'url': <?php echo wp_json_encode($url_to_share) ?>,
                 });
                 typeof window.gtag === 'function' && gtag('event', 'share_button_click', {
                     'event_category': 'engagement',
                     'event_label': buttonId.split('-')[2],
-                    'message': "<?php echo $share_message ?>",
-                    'url': "<?php echo $url_to_share ?>"
+                    'message': <?php echo wp_json_encode($share_message) ?>,
+                    'url': <?php echo wp_json_encode($url_to_share) ?>
                 });
             });
         }

--- a/wp-content/themes/academyAfrica/template-parts/social_share.php
+++ b/wp-content/themes/academyAfrica/template-parts/social_share.php
@@ -33,7 +33,7 @@ $share_message = isset($args["message"]) ? $args["message"] : sprintf(academyafr
 <script>
     function toggleShareButtons() {
         var shareButtons = document.querySelector('.share-icons');
-        shareButtons.classList.toggle('hide');
+        if (shareButtons) shareButtons.classList.toggle('hide');
     }
 
     const shareButtons = ['share-btn-linkedin', 'share-btn-twitter', 'share-btn-facebook', 'share-btn-instagram'];
@@ -48,7 +48,7 @@ $share_message = isset($args["message"]) ? $args["message"] : sprintf(academyafr
                     'platform': buttonId.split('-')[2],
                     'url': "<?php echo $url_to_share ?>",
                 });
-                gtag('event', 'share_button_click', {
+                typeof window.gtag === 'function' && gtag('event', 'share_button_click', {
                     'event_category': 'engagement',
                     'event_label': buttonId.split('-')[2],
                     'message': "<?php echo $share_message ?>",


### PR DESCRIPTION
Closes #55

Audit findings 36–40 (excluding privately-tracked security cases). Three areas.

## Markup — one `<main>` landmark per document (finding 39)
`header.php` opened a `<main>` immediately after `<body>` (wrapping the site nav) that **was never closed** by the footer, while page templates and widgets opened **their own** `<main>` inside it — producing unclosed *and* nested landmarks on essentially every page.

- `header.php` now renders the nav **outside** `<main>` and opens a single `<main id="content">` (which also fixes the previously-dangling `#content` skip-link target). `footer.php` and `404.php` close it.
- The per-template / per-widget `<main class="…">` elements are demoted to `<div>`: contact-us, page-content, edit-profile, single-event, template-parts/404, and the all_courses / my_courses / events / learning_pathways / home_learning_pathways widgets. **CSS is entirely class-based (no `main`-element selectors), so styling is unchanged** — verified against the compiled CSS.

Result: exactly one properly-closed `<main>` per document (including login / search / single-resource / single-ac-learning-path, which had none of their own).

## JavaScript — guard DOM lookups and optional globals (findings 36–38)
- `header.js` (loads on every page): guards for hamburger/drawer/icons, child-nav toggles, search toggles, and the user-avatar injection.
- `gtag()` calls wrapped in `typeof window.gtag === 'function'` (searchform, course_card, social_share, certificate, password-reset, login, register, single-ac-learning-path) — matching the already-guarded 404 tracker.
- Third-party/global guards: `window.jspdf` (course_completed, my_courses), `Swiper` (slider), `#filter-modal` (search.js), `.ribbon` (learndash_course_grid.js), and inline element lookups (login `#wp-submit`, course_card, social_share, register password fields, learning-path print, edit-profile avatar preview).

## Output escaping — explicit, context-aware (finding 40)
- **`search.php`**: the reflected `$_GET` organization filter is now `esc_html` (text) / `esc_js` (JS-in-attribute); search term, sort options, and pagination links escaped with `esc_html` / `esc_attr` / `esc_url`.
- **`single-event.php`, `single-ac-learning-path.php`, `single-resource.php`**: `esc_url` on URLs, `esc_html` on text, `esc_attr` on attributes, `wp_kses_post` on rich content, `esc_js` on values written into JS.
- **`template-parts/header.php` (nav) and `template-parts/footer.php`**: `esc_url` / `esc_attr` / `esc_html` on menu and widget output. The newsletter embed is left as-is with a comment documenting it as an admin-only **trusted-content exception** (`wp_kses_post` would strip the embed `<form>`).

## Done when
- ✅ Key pages render without browser exceptions when optional elements or analytics are absent
- ✅ Generated HTML has one correctly-nested `<main>` (structural/accessibility)
- ✅ Dynamic output has explicit, reviewable escaping decisions
