### PR TITLE
fix(theme): fix All Courses grid card layout (sfwd-common regression from #51)

### DIFF
--- a/wp-content/themes/academyAfrica/functions.php
+++ b/wp-content/themes/academyAfrica/functions.php
@@ -40,6 +40,11 @@ function my_theme_enqueue_styles()
     // Base styles — needed on every front-end page.
     wp_enqueue_style('child-style', $base . 'main.css', array('hello-elementor', 'hello-elementor-theme-style'), ACADEMY_AFRICA_VERSION);
     wp_enqueue_style('default-page-content', $base . 'pages/page-content.css', array(), ACADEMY_AFRICA_VERSION);
+    // sfwd-common styles the shared course-card component (.course-card .card),
+    // which renders in the course grids on many pages (courses, my courses,
+    // learning paths, home, etc.), not just LearnDash single views — so it is a
+    // site-wide base style, not a page-specific bundle.
+    wp_enqueue_style('sfwd-common', $base . 'pages/sfwd-common.css', array(), ACADEMY_AFRICA_VERSION);
 
     // Page-specific bundles — loaded only where the page actually needs them so
     // unrelated pages don't ship course/event/profile/auth CSS.
@@ -59,9 +64,6 @@ function my_theme_enqueue_styles()
     }
 
     // LearnDash single content (course, lesson, quiz, topic).
-    if (is_singular(array('sfwd-courses', 'sfwd-lessons', 'sfwd-quiz', 'sfwd-topic'))) {
-        wp_enqueue_style('sfwd-common', $base . 'pages/sfwd-common.css', array(), ACADEMY_AFRICA_VERSION);
-    }
     if (is_singular('sfwd-courses')) {
         wp_enqueue_style('single-courses', $base . 'pages/single-sfwd-courses.css', array(), ACADEMY_AFRICA_VERSION);
         wp_enqueue_style('course-completed', $base . 'pages/course-completed.css', array(), ACADEMY_AFRICA_VERSION);

--- a/wp-content/themes/academyAfrica/functions.php
+++ b/wp-content/themes/academyAfrica/functions.php
@@ -29,7 +29,7 @@ add_action('wp_enqueue_scripts', 'child_theme_configurator_css', 10);
 
 // END ENQUEUE PARENT ACTION
 
-define('ACADEMY_AFRICA_VERSION', '1.7.16');
+define('ACADEMY_AFRICA_VERSION', '1.7.17');
 const MINIMUM_ELEMENTOR_VERSION = '3.16.6';
 
 


### PR DESCRIPTION
## Problem

The **All Courses** page (`/courses/`) renders its course cards full-width/stacked instead of in the multi-column grid — the cards lost their `280px` width.

## Root cause

PR #51 (conditional asset loading) gated `sfwd-common.css` to `is_singular(['sfwd-courses','sfwd-lessons','sfwd-quiz','sfwd-topic'])`, treating it as LearnDash single-page CSS. But that file also contains the **shared course-card component** rule:

```css
.course-card .card { width: 280px }
```

`/courses/` is a regular Elementor page (not a LearnDash singular), so `sfwd-common.css` no longer loaded there and the grid cards lost their width.

Only the All Courses grid broke: the other grids (My Courses, Learning Paths, Featured, home) get their card widths from their **own** widget stylesheets, which `register_styles()` enqueues globally — so they were unaffected. Confirmed live: with `sfwd-common` loaded, `.course-card .card` computes to `280px` and the grid renders correctly again.

## Fix

`sfwd-common.css` carries a shared component (`.course-card`, plus common `button`/`wysiwyg` rules) rendered across many surfaces — the All Courses & Featured widgets, search, single learning path, single course, and the print template. Enqueue it as a **base/site-wide** style rather than a LearnDash-single page bundle.