### PR TITLE
fix(theme): apply LearnDash single-view styles where quizzes/lessons render (#51 regression)

### DIFF
--- a/wp-content/themes/academyAfrica/functions.php
+++ b/wp-content/themes/academyAfrica/functions.php
@@ -29,7 +29,7 @@ add_action('wp_enqueue_scripts', 'child_theme_configurator_css', 10);
 
 // END ENQUEUE PARENT ACTION
 
-define('ACADEMY_AFRICA_VERSION', '1.7.17');
+define('ACADEMY_AFRICA_VERSION', '1.7.18');
 const MINIMUM_ELEMENTOR_VERSION = '3.16.6';
 
 
@@ -63,18 +63,17 @@ function my_theme_enqueue_styles()
         wp_enqueue_style('contact-us', $base . 'pages/contact-us.css', array(), ACADEMY_AFRICA_VERSION);
     }
 
-    // LearnDash single content (course, lesson, quiz, topic).
-    if (is_singular('sfwd-courses')) {
+    // LearnDash content is nested: a course page renders its lessons, topics
+    // and quizzes; a lesson page renders its quizzes; and LearnDash serves a
+    // quiz URL inside the course/lesson context (e.g. /quizzes/x/ resolves to
+    // is_singular('sfwd-courses')). So load every LearnDash single-view style
+    // on any LearnDash singular page rather than gating each to its exact post
+    // type — otherwise e.g. the quiz styles never apply when a quiz is taken.
+    if (is_singular(array('sfwd-courses', 'sfwd-lessons', 'sfwd-quiz', 'sfwd-topic'))) {
         wp_enqueue_style('single-courses', $base . 'pages/single-sfwd-courses.css', array(), ACADEMY_AFRICA_VERSION);
         wp_enqueue_style('course-completed', $base . 'pages/course-completed.css', array(), ACADEMY_AFRICA_VERSION);
-    }
-    if (is_singular('sfwd-lessons')) {
         wp_enqueue_style('single-lesson', $base . 'pages/single-sfwd-lessons.css', array(), ACADEMY_AFRICA_VERSION);
-    }
-    if (is_singular('sfwd-quiz')) {
         wp_enqueue_style('single-quiz', $base . 'pages/single-sfwd-quiz.css', array(), ACADEMY_AFRICA_VERSION);
-    }
-    if (is_singular('sfwd-topic')) {
         wp_enqueue_style('single-topic', $base . 'pages/single-sfwd-topic.css', array(), ACADEMY_AFRICA_VERSION);
     }
 


### PR DESCRIPTION
## Problem

Custom single-quiz styles aren't applied — e.g. `.ld-quiz-question-item__status { display: none !important }` (from `single-sfwd-quiz.css`) doesn't take effect when taking a quiz.

## Root cause

PR #51 (conditional asset loading) gated each LearnDash `single-*` stylesheet to `is_singular()` of its **exact** post type. But LearnDash serves its content nested: a quiz URL like `/quizzes/x/` **resolves to `is_singular('sfwd-courses')`** (the quiz renders inside the course/lesson context, body class `single-sfwd-courses`), not `is_singular('sfwd-quiz')`. So `single-sfwd-quiz.css` never loaded where a quiz is actually taken, and its rules didn't apply.

Same class of regression as the All Courses grid fix (#72): #51's per-type gating was too narrow for LearnDash's nested rendering.

## Fix

Load **all** the LearnDash single-view styles (`single-courses`, `course-completed`, `single-lesson`, `single-quiz`, `single-topic`) on **any** LearnDash singular page (`is_singular(['sfwd-courses','sfwd-lessons','sfwd-quiz','sfwd-topic'])`), instead of gating each to its own post type. They still don't ship on unrelated pages, so #51's goal (no course CSS on the homepage/etc.) is preserved.

## Verification (local)

On a course page (`is_singular('sfwd-courses')`, where a quiz is taken):
- the `single-quiz` bundle now loads, and
- `.ld-quiz-question-item__status { display: none !important }` is present and active in the CSSOM.

(Note: `single-sfwd-lessons.css` is a 54-byte empty file, so WP-Optimize emits no bundle for it — harmless.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)